### PR TITLE
fix(version): use hatch-vcs for dynamic version from git tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "context-harness"
-version = "1.4.0"
+dynamic = ["version"]
 description = "CLI installer for the ContextHarness agent framework for OpenCode.ai"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -35,8 +35,14 @@ Repository = "https://github.com/cmtzco/context-harness"
 Issues = "https://github.com/cmtzco/context-harness/issues"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.version.raw-options]
+fallback_version = "0.0.0+unknown"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/context_harness"]

--- a/src/context_harness/__init__.py
+++ b/src/context_harness/__init__.py
@@ -1,3 +1,9 @@
 """ContextHarness CLI - Initialize agent frameworks in your project."""
 
-__version__ = "1.4.0"
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("context-harness")
+except PackageNotFoundError:
+    # Package is not installed (running from source without install)
+    __version__ = "0.0.0+unknown"

--- a/uv.lock
+++ b/uv.lock
@@ -47,7 +47,6 @@ wheels = [
 
 [[package]]
 name = "context-harness"
-version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary

- **Problem**: CLI showed hardcoded `v1.4.0` even after semantic-release created new tags
- **Solution**: Use `hatch-vcs` to derive version dynamically from git tags at build time

## Changes

- Remove hardcoded version from `pyproject.toml` and `__init__.py`
- Add `hatch-vcs` plugin to `build-system.requires`
- Configure `[tool.hatch.version]` with `source = "vcs"`
- Use `importlib.metadata.version()` for runtime version access
- Add `fallback_version = "0.0.0+unknown"` for environments without git history

## Testing

```bash
# Version now derived from git tags
$ uv run context-harness --version
context-harness, version 1.4.1.dev2+g439cbb57e.d20251205

# All tests pass
$ uv run pytest tests/ -v
12 passed
```

## How it Works

1. At **build time**: `hatch-vcs` reads version from git tags (e.g., `v1.5.0` → `1.5.0`)
2. At **runtime**: `importlib.metadata.version()` reads from installed package metadata
3. Between releases: Version shows dev suffix (e.g., `1.4.1.dev2+gHASH`)
4. On tagged releases: Clean version (e.g., `1.5.0`)

Closes the version mismatch issue reported for uvx installations.