### PR TITLE
docs(sessions): update completed session files with GitHub integration links

### DIFF
--- a/.context-harness/sessions/commands/SESSION.md
+++ b/.context-harness/sessions/commands/SESSION.md
@@ -1,7 +1,7 @@
 # ContextHarness Session
 
 **Session**: commands
-**Last Updated**: 2025-12-05  
+**Last Updated**: 2025-12-06  
 **Compaction Cycle**: #1  
 **Session Started**: 2025-12-05
 
@@ -10,11 +10,18 @@
 ## Active Work
 
 **Current Task**: Implement OpenCode slash commands for session management  
-**Status**: Completed  
+**Status**: ✅ Completed  
 **Description**: Create actual OpenCode custom commands (/ctx, /compact, /contexts) that get installed during `context-harness init`  
 **Blockers**: None
 
-**GitHub Issue**: https://github.com/cmtzco/context-harness/issues/17
+---
+
+## GitHub Integration
+
+**Branch**: feature/opencode-slash-commands (merged)
+**Issue**: #17 - https://github.com/cmtzco/context-harness/issues/17 (CLOSED)
+**PR**: #20 - https://github.com/cmtzco/context-harness/pull/20 (MERGED)
+**Release**: v2.2.0
 
 ---
 
@@ -47,19 +54,14 @@
 |-------|-----|-----------|
 | OpenCode Commands Docs | https://opencode.ai/docs/commands/ | Reference for command format, frontmatter options, $ARGUMENTS usage |
 | GitHub Issue #17 | https://github.com/cmtzco/context-harness/issues/17 | Feature specification and acceptance criteria |
+| PR #20 | https://github.com/cmtzco/context-harness/pull/20 | Feature implementation |
+| Release v2.2.0 | https://github.com/cmtzco/context-harness/releases/tag/v2.2.0 | Release notes |
 
 ---
 
 ## Next Steps
 
-1. ~~Create `.opencode/command/` directory in templates~~ ✅
-2. ~~Create `ctx.md` command file~~ ✅
-3. ~~Create `compact.md` command file~~ ✅
-4. ~~Create `contexts.md` command file~~ ✅
-5. ~~Update `installer.py` to copy command directory~~ ✅
-6. ~~Update README documentation~~ ✅
-7. ~~Add tests for command installation~~ ✅
-8. Create PR and merge to main
+All tasks completed. Feature released in v2.2.0.
 
 ---
 
@@ -118,4 +120,4 @@ Command prompt template with $ARGUMENTS placeholder
 
 ---
 
-_Auto-updated by ContextHarness Primary Agent every 2nd user interaction_
+_Session completed - Feature released in v2.2.0_

--- a/.context-harness/sessions/contexts-subagent/SESSION.md
+++ b/.context-harness/sessions/contexts-subagent/SESSION.md
@@ -1,7 +1,7 @@
 # ContextHarness Session
 
 **Session**: contexts-subagent
-**Last Updated**: 2025-12-05  
+**Last Updated**: 2025-12-06  
 **Compaction Cycle**: #0  
 **Session Started**: 2025-12-05
 
@@ -10,7 +10,7 @@
 ## Active Work
 
 **Current Task**: Create contexts-subagent to reduce primary agent context burn  
-**Status**: Implementation Complete  
+**Status**: ✅ Completed  
 **Description**: Delegate `/contexts` command to a new subagent that handles session discovery and summarization, returning a concise result to the primary agent  
 **Blockers**: None
 
@@ -18,9 +18,10 @@
 
 ## GitHub Integration
 
-**Branch**: feature/opencode-slash-commands
-**Issue**: #21 - https://github.com/cmtzco/context-harness/issues/21
-**PR**: (ready to create)
+**Branch**: feature/contexts-subagent (merged)
+**Issue**: #21 - https://github.com/cmtzco/context-harness/issues/21 (CLOSED)
+**PR**: #22 - https://github.com/cmtzco/context-harness/pull/22 (MERGED)
+**Release**: v2.3.0
 
 ---
 
@@ -53,19 +54,15 @@
 | Title | URL | Relevance |
 |-------|-----|-----------|
 | GitHub Issue #21 | https://github.com/cmtzco/context-harness/issues/21 | Feature specification |
+| PR #22 | https://github.com/cmtzco/context-harness/pull/22 | Feature implementation |
+| Release v2.3.0 | https://github.com/cmtzco/context-harness/releases/tag/v2.3.0 | Release notes |
 | Research Subagent | `.opencode/agent/research-subagent.md` | Template for subagent structure |
 
 ---
 
 ## Next Steps
 
-1. ~~Create `contexts-subagent.md` agent definition~~ ✅
-2. ~~Add template to `src/context_harness/templates/.opencode/agent/`~~ ✅
-3. ~~Update `/contexts` command to route to `contexts-subagent`~~ ✅
-4. ~~Update `installer.py` to include new subagent~~ ✅
-5. ~~Add tests for subagent installation~~ ✅
-6. ~~Update README documentation~~ ✅
-7. Create PR and merge
+All tasks completed. Feature released in v2.3.0.
 
 ---
 
@@ -112,4 +109,4 @@
 
 ---
 
-_Auto-updated by ContextHarness Primary Agent every 2nd user interaction_
+_Session completed - Feature released in v2.3.0_

--- a/.context-harness/sessions/framework-setup/SESSION.md
+++ b/.context-harness/sessions/framework-setup/SESSION.md
@@ -1,18 +1,29 @@
 # ContextHarness Session
 
 **Session**: framework-setup
-**Last Updated**: 2025-12-04T07:15:45Z  
+**Last Updated**: 2025-12-06  
 **Compaction Cycle**: #0  
-**Session Started**: 2025-12-04T07:15:45Z
+**Session Started**: 2025-12-04
 
 ---
 
 ## Active Work
 
 **Current Task**: ContextHarness Framework Setup  
-**Status**: Completed  
+**Status**: ✅ Completed  
 **Description**: Initial framework creation with all agent files and directory structure  
 **Blockers**: None
+
+---
+
+## GitHub Integration
+
+**Note**: This was the foundational session that established the ContextHarness framework itself. No GitHub issue was created as this predates the issue-tracking workflow.
+
+**Initial PRs**:
+- PR #4 - Enhanced research subagent with Context7 MCP
+- PR #6 - Fix Context7 MCP tool configuration
+- PR #8 - Replace Context7 code examples with usage tips
 
 ---
 
@@ -51,11 +62,7 @@
 
 ## Next Steps
 
-1. Test the Primary Agent activation and greeting
-2. Test compaction cycle triggering (every 2nd message)
-3. Test subagent invocations (@research-subagent, @docs-subagent, @compaction-guide)
-4. Verify SESSION.md updates correctly during compaction
-5. Create framework README.md documentation
+Framework setup completed. This session established the foundation for all future ContextHarness development.
 
 ---
 
@@ -89,4 +96,4 @@
 
 ---
 
-_Auto-updated by ContextHarness Primary Agent every 2nd user interaction_
+_Session completed - Foundational framework established_

--- a/.context-harness/sessions/github-workflow/SESSION.md
+++ b/.context-harness/sessions/github-workflow/SESSION.md
@@ -1,7 +1,7 @@
 # ContextHarness Session
 
 **Session**: github-workflow
-**Last Updated**: 2025-12-05  
+**Last Updated**: 2025-12-06  
 **Compaction Cycle**: #1  
 **Session Started**: 2025-12-05
 
@@ -10,7 +10,7 @@
 ## Active Work
 
 **Current Task**: GitHub-integrated session workflow feature  
-**Status**: Implementation Complete - PR Created  
+**Status**: ✅ Completed  
 **Description**: Integrate GitHub workflow into ContextHarness - auto branch creation, issue tracking, PR workflow  
 **Blockers**: None
 
@@ -18,9 +18,12 @@
 
 ## GitHub Integration
 
-**Branch**: feature/github-workflow-integration
-**Issue**: #19 - https://github.com/cmtzco/context-harness/issues/19
-**PR**: #24 - https://github.com/cmtzco/context-harness/pull/24
+**Branch**: feature/github-workflow-integration (merged)
+**Issue**: #19 - https://github.com/cmtzco/context-harness/issues/19 (CLOSED)
+**PRs**: 
+- PR #23 - https://github.com/cmtzco/context-harness/pull/23 (MERGED) - Session file
+- PR #24 - https://github.com/cmtzco/context-harness/pull/24 (MERGED) - Feature implementation
+**Release**: v2.4.0
 
 ---
 
@@ -55,17 +58,15 @@
 |-------|-----|-----------|
 | GitHub CLI Manual | https://cli.github.com/manual/ | Core tool for issue/PR creation |
 | GitHub Issue #19 | https://github.com/cmtzco/context-harness/issues/19 | The feature request itself |
+| PR #23 | https://github.com/cmtzco/context-harness/pull/23 | Session file commit |
+| PR #24 | https://github.com/cmtzco/context-harness/pull/24 | Feature implementation |
+| Release v2.4.0 | https://github.com/cmtzco/context-harness/releases/tag/v2.4.0 | Release notes |
 
 ---
 
 ## Next Steps
 
-1. ✅ ~~Create feature branch `feature/github-workflow-integration`~~
-2. ✅ ~~Modify `/ctx` command to create branches~~
-3. ✅ ~~Add issue creation prompt and logic~~
-4. ✅ ~~Add `/issue update` and `/pr` commands~~
-5. ✅ ~~Create PR #24~~
-6. **Await PR review and merge**
+All tasks completed. Feature released in v2.4.0.
 
 ---
 
@@ -103,4 +104,4 @@ The irony: We used this session to build the feature that would automate this se
 
 ---
 
-_Auto-updated by ContextHarness Primary Agent every 2nd user interaction_
+_Session completed - Feature released in v2.4.0_


### PR DESCRIPTION
## Summary

Updates all completed session files to include proper GitHub integration links (issues, PRs, releases) and mark them as completed.

### Changes

| Session | Issue | PR | Release | Status |
|---------|-------|-----|---------|--------|
| **commands** | #17 | #20 | v2.2.0 | ✅ Completed |
| **contexts-subagent** | #21 | #22 | v2.3.0 | ✅ Completed |
| **github-workflow** | #19 | #23, #24 | v2.4.0 | ✅ Completed |
| **framework-setup** | N/A (foundational) | #4, #6, #8 | N/A | ✅ Completed |

**Note**: `baseline-command` was already updated in PR #26, and `framework-setup` predates the issue-tracking workflow as it was the foundational session that established the framework.