### PR TITLE
feat(agents): add design tokens and UI extraction to baseline discovery

### DIFF
--- a/src/context_harness/templates/.opencode/agent/baseline-answers.md
+++ b/src/context_harness/templates/.opencode/agent/baseline-answers.md
@@ -54,9 +54,22 @@ You receive two inputs:
   "frameworks_and_libraries": {...},
   "build_toolchain": {...},
   "external_dependencies": {...},
-  "project_patterns": {...}
+  "project_patterns": {...},
+  "design_system": {
+    "has_frontend": true | false,
+    "ui_framework": "...",
+    "styling_approach": "...",
+    "component_library": "...",
+    "design_tokens": {...},
+    "color_system": {...},
+    "typography": {...},
+    "spacing": {...},
+    "icons": {...}
+  }
 }
 ```
+
+**NOTE**: If `design_system.has_frontend` is `false`, skip the "Design System & UI" section entirely in the output.
 
 ### 2. Validated Questions (from Phase 2)
 ```json
@@ -261,6 +274,54 @@ You MUST generate markdown content in this exact structure:
 
 ---
 
+## Design System & UI
+
+**NOTE**: This section is only included if the project has frontend/UI components. Skip this section entirely for backend-only projects.
+
+### Design System Overview
+
+| Aspect | Value |
+|--------|-------|
+| **UI Framework** | {React/Vue/Angular/Svelte/none} |
+| **Styling Approach** | {Tailwind/CSS Modules/styled-components/etc.} |
+| **Component Library** | {Chakra/MUI/Radix/Shadcn/custom/none} |
+| **Design Tokens** | {CSS variables/Tailwind config/JS theme/none} |
+| **Dark Mode** | {Yes (strategy)/No} |
+| **Icon Library** | {Lucide/Heroicons/custom/none} |
+
+### Q: {Question about design tokens}
+
+**Answer**: {Detailed answer}
+
+**Evidence**:
+- `{file_path}:{line_number}` - {relevant code or quote}
+
+**Confidence**: {High|Medium|Low}
+
+---
+
+### Q: {Question about color system}
+
+**Answer**: {Detailed answer}
+
+**Evidence**:
+- `{file_path}:{line_number}` - {relevant code or quote}
+
+**Confidence**: {High|Medium|Low}
+
+---
+
+### Q: {Question about typography}
+
+**Answer**: {Detailed answer}
+
+**Evidence**:
+- `{file_path}:{line_number}` - {relevant code or quote}
+
+**Confidence**: {High|Medium|Low}
+
+---
+
 ## Unanswered Questions
 
 The following questions could not be answered from the codebase:
@@ -328,6 +389,7 @@ Answered [X]/[Y] questions with [Z] high confidence answers.
 | Build/Distribution | X | X | X | X | X |
 | Security/Auth | X | X | X | X | X |
 | Performance | X | X | X | X | X |
+| Design System & UI | X | X | X | X | X |
 | **Total** | X | X | X | X | X |
 
 ## Key Insights

--- a/src/context_harness/templates/.opencode/agent/baseline-discovery.md
+++ b/src/context_harness/templates/.opencode/agent/baseline-discovery.md
@@ -138,6 +138,75 @@ Detection Method:
 5. Look for infrastructure directories (terraform/, k8s/)
 ```
 
+### Phase 5: Design System & UI Detection (Conditional)
+
+**ONLY execute this phase if frontend/UI presence is detected** (React, Vue, Angular, Svelte, CSS files, etc.)
+
+```
+Design Token Sources:
+├── CSS Custom Properties:
+│   ├── :root { --color-*, --font-*, --spacing-* }
+│   ├── Global CSS files (globals.css, variables.css, tokens.css)
+│   └── CSS Modules with custom properties
+├── Tailwind CSS:
+│   ├── tailwind.config.js/ts
+│   ├── theme.extend.colors, theme.extend.fontFamily
+│   └── Custom plugins and presets
+├── CSS-in-JS Themes:
+│   ├── styled-components: ThemeProvider, DefaultTheme
+│   ├── Emotion: ThemeProvider, @emotion/react
+│   ├── Stitches: createStitches, theme tokens
+│   └── Vanilla Extract: createTheme, style contracts
+├── Design Token Files:
+│   ├── tokens.json, design-tokens.json
+│   ├── tokens/, design-tokens/, design-system/
+│   ├── Style Dictionary configurations
+│   └── Figma token exports
+└── Component Libraries:
+    ├── Chakra UI: @chakra-ui/*, extendTheme
+    ├── Material UI: @mui/*, createTheme
+    ├── Radix UI: @radix-ui/*
+    ├── Shadcn/ui: components.json, cn() utility
+    ├── Ant Design: antd, ConfigProvider
+    └── Headless UI: @headlessui/*
+
+Color System Detection:
+├── Semantic colors: primary, secondary, accent, success, warning, error
+├── Color scales: gray-50 to gray-900, blue-100 to blue-900
+├── Brand colors: brand-*, logo-*, company-specific
+├── Dark mode: prefers-color-scheme, .dark class, data-theme
+└── Color formats: hex, rgb, hsl, oklch, CSS variables
+
+Typography Detection:
+├── Font families: sans, serif, mono, display, body, heading
+├── Font scales: xs, sm, base, lg, xl, 2xl... or numeric
+├── Line heights: tight, normal, relaxed, loose
+├── Font weights: thin to black, 100-900
+└── Font sources: Google Fonts, local fonts, @font-face
+
+Spacing & Layout Detection:
+├── Spacing scales: 0, 1, 2, 4, 8, 16... or semantic (xs, sm, md)
+├── Grid systems: CSS Grid, Flexbox patterns, 12-column
+├── Breakpoints: sm, md, lg, xl, 2xl or pixel values
+├── Container widths: max-w-*, container queries
+└── Z-index scales: modal, dropdown, tooltip layers
+
+Icon System Detection:
+├── Icon libraries: lucide-react, heroicons, @phosphor-icons
+├── Icon sprites: SVG sprites, icon fonts
+├── Custom icons: icons/, assets/icons/
+└── Icon components: Icon.tsx, SvgIcon patterns
+
+Detection Method:
+1. Check for UI framework dependencies in package.json
+2. Search for tailwind.config.* files
+3. Glob for CSS/SCSS files with :root or custom properties
+4. Look for theme.ts/js files or ThemeProvider usage
+5. Check for design-tokens/ or tokens/ directories
+6. Parse component library configurations
+7. Search for color/font/spacing patterns in styles
+```
+
 ---
 
 ## Output Format
@@ -238,6 +307,46 @@ You MUST output a valid JSON object with this structure:
     "code_organization": "feature-based | layer-based | domain-driven",
     "api_style": "REST | GraphQL | gRPC | none",
     "authentication_pattern": "JWT | session | OAuth | none detected"
+  },
+  
+  "design_system": {
+    "has_frontend": true | false,
+    "detection_skipped_reason": "No frontend/UI detected | null",
+    "ui_framework": "React | Vue | Angular | Svelte | null",
+    "styling_approach": "Tailwind | CSS Modules | styled-components | Emotion | Vanilla CSS | null",
+    "component_library": "Chakra UI | Material UI | Radix | Shadcn | Ant Design | custom | null",
+    "design_tokens": {
+      "source": "CSS custom properties | Tailwind config | Theme file | tokens.json | none",
+      "location": "path/to/tokens or config file",
+      "format": "CSS variables | JS object | JSON | Style Dictionary"
+    },
+    "color_system": {
+      "approach": "semantic | scale-based | brand-focused | minimal",
+      "dark_mode": true | false,
+      "dark_mode_strategy": "CSS variables | class toggle | media query | none",
+      "colors_detected": ["primary", "secondary", "accent", "gray scale", etc.]
+    },
+    "typography": {
+      "font_source": "Google Fonts | local | system | mixed",
+      "font_families": ["sans-serif family name", "mono family name"],
+      "scale_type": "modular | linear | custom",
+      "heading_font": "font name or null",
+      "body_font": "font name or null"
+    },
+    "spacing": {
+      "scale_type": "4px base | 8px base | rem-based | custom",
+      "uses_design_tokens": true | false
+    },
+    "icons": {
+      "library": "Lucide | Heroicons | Phosphor | custom | none",
+      "format": "React components | SVG sprites | icon font"
+    },
+    "evidence": {
+      "config_files": ["tailwind.config.js", "theme.ts", etc.],
+      "style_files": ["globals.css", "variables.scss", etc.],
+      "token_files": ["tokens.json", "design-tokens/", etc.]
+    },
+    "confidence": 0.0-1.0
   },
   
   "analysis_metadata": {

--- a/src/context_harness/templates/.opencode/agent/baseline-questions.md
+++ b/src/context_harness/templates/.opencode/agent/baseline-questions.md
@@ -55,9 +55,22 @@ You receive a discovery report JSON from @baseline-discovery:
   "build_toolchain": {...},
   "external_dependencies": {...},
   "project_patterns": {...},
+  "design_system": {
+    "has_frontend": true | false,
+    "ui_framework": "...",
+    "styling_approach": "...",
+    "component_library": "...",
+    "design_tokens": {...},
+    "color_system": {...},
+    "typography": {...},
+    "spacing": {...},
+    "icons": {...}
+  },
   "analysis_metadata": {...}
 }
 ```
+
+**NOTE**: If `design_system.has_frontend` is `false`, skip generating questions for the "Design System & UI" category entirely.
 
 ---
 
@@ -132,6 +145,35 @@ Questions about performance considerations:
 - "Are there any known performance bottlenecks documented?"
 - "What monitoring and alerting is in place?"
 - "How would this application scale horizontally?"
+
+### 8. Design System & UI (Conditional)
+
+**ONLY generate questions in this category if `design_system.has_frontend` is `true` in the discovery report.**
+
+Questions about visual design, styling, and UI consistency:
+
+**Examples:**
+- "What design token system is used and how are colors organized?"
+- "How is the color palette structured (semantic vs scale-based)?"
+- "What typography scale is used and how are font sizes determined?"
+- "How does dark mode switching work and what strategy is used?"
+- "What component library was chosen and why?"
+- "How are design tokens maintained and distributed across the codebase?"
+- "What is the spacing scale based on (4px, 8px, or custom)?"
+- "How are icons managed and what library is used?"
+- "Is there a design system documentation or Storybook instance?"
+- "How do CSS custom properties integrate with the JavaScript framework?"
+- "What approach is used for responsive breakpoints?"
+- "How is visual consistency enforced across components?"
+
+**Evidence locations to check:**
+- `tailwind.config.js/ts` - Tailwind theme configuration
+- `theme.ts/js` - CSS-in-JS theme definitions
+- `tokens.json`, `design-tokens/` - Design token files
+- `globals.css`, `variables.css` - CSS custom properties
+- `components.json` - Shadcn/ui configuration
+- `.storybook/` - Storybook configuration
+- `styled.d.ts` - styled-components type definitions
 
 ---
 
@@ -253,7 +295,8 @@ You MUST output a valid JSON object with this structure:
     "language_framework_choice": 4,
     "build_distribution": 5,
     "security_authentication": 4,
-    "performance_scaling": 3
+    "performance_scaling": 3,
+    "design_system_ui": 4
   },
   
   "regeneration_needed": false,
@@ -292,6 +335,7 @@ Generated [X] questions, [Y] passed validation (score >= 8.0).
 | Build & Distribution | X | Y | Z% |
 | Security & Auth | X | Y | Z% |
 | Performance & Scaling | X | Y | Z% |
+| Design System & UI | X | Y | Z% |
 
 ## Top 5 Questions (Highest Score)
 1. **[Q###]** (Score: X.XX): [Question text]


### PR DESCRIPTION
## Summary

- Add design tokens and UI component extraction capability to the `/baseline` command
- Enables comprehensive design system documentation for frontend projects

## Changes

### Phase 5: Design System & UI Detection (`baseline-discovery.md`)

New conditional detection phase that activates when frontend/UI presence is detected:

- **Design Token Sources**: CSS custom properties, Tailwind config, CSS-in-JS themes (styled-components, Emotion, Stitches, Vanilla Extract), Style Dictionary, Figma token exports
- **Color System**: Semantic colors, color scales, brand colors, dark mode strategies
- **Typography**: Font families, scales, sources (Google Fonts, local, system)
- **Spacing**: Scale types (4px, 8px, rem-based), design token usage
- **Icons**: Library detection (Lucide, Heroicons, Phosphor), format identification
- **Component Libraries**: Chakra UI, Material UI, Radix, Shadcn/ui, Ant Design, Headless UI

### Design System & UI Question Category (`baseline-questions.md`)

- New category 8 with 12 example questions covering design tokens, colors, typography, theming
- Conditional generation: only when `design_system.has_frontend` is `true`
- Evidence location hints for design-related files

### Design System Output Section (`baseline-answers.md`)

- New "Design System & UI" section in PROJECT-CONTEXT.md output
- Design System Overview table with key attributes
- Structured Q&A format for design questions
- Updated statistics table with new category row

## Testing

This is a documentation/agent enhancement. The changes are:
1. Additive - no existing functionality is modified
2. Conditional - only applies when frontend components are detected
3. Backend-only projects are unaffected (section skipped entirely)

Closes #30