### PR TITLE
chore: close remove-model-config session after merge

### DIFF
--- a/.context-harness/sessions/remove-model-config/SESSION.md
+++ b/.context-harness/sessions/remove-model-config/SESSION.md
@@ -1,0 +1,118 @@
+# ContextHarness Session
+
+**Session**: remove-model-config
+**Last Updated**: 2025-12-22
+**Compaction Cycle**: #2
+**Session Started**: 2025-12-22
+**Session Closed**: 2025-12-22
+
+---
+
+## Active Work
+
+**Current Task**: Remove hardcoded model configurations from agent files
+**Status**: ✅ Merged
+**Description**: Made ContextHarness agents model-agnostic by removing the `model` field from all `.opencode/agent/*.md` files. Users can now configure models via `opencode.json` instead.
+**Blockers**: None
+
+---
+
+## Key Files
+
+| File | Purpose | Status |
+|------|---------|--------|
+| .opencode/agent/context-harness.md | Primary agent definition | ✅ Merged |
+| .opencode/agent/research-subagent.md | Research subagent | ✅ Merged |
+| .opencode/agent/docs-subagent.md | Documentation subagent | ✅ Merged |
+| .opencode/agent/compaction-guide.md | Compaction guide subagent | ✅ Merged |
+| .opencode/agent/baseline-discovery.md | Baseline discovery subagent | ✅ Merged |
+| .opencode/agent/baseline-questions.md | Baseline questions subagent | ✅ Merged |
+| .opencode/agent/baseline-answers.md | Baseline answers subagent | ✅ Merged |
+| .opencode/agent/contexts-subagent.md | Contexts listing subagent | ✅ Merged |
+| src/context_harness/templates/.opencode/agent/*.md | All 8 template files | ✅ Merged |
+| DOCS.md | Added Model Configuration section | ✅ Merged |
+
+---
+
+## Decisions Made
+
+| Decision | Choice | Rationale | Date |
+|----------|--------|-----------|------|
+| Model config location | Remove from agent files, use opencode.json | OpenCode docs confirm model is optional; users should control model choice | 2025-12-22 |
+| Keep other frontmatter | Preserve description, mode, temperature, tools | These are agent-specific and appropriate to keep | 2025-12-22 |
+| Track .opencode/ in repo | Add root .opencode/ directory to git | Was previously untracked; needed for development/testing | 2025-12-22 |
+| Keep bash:true for baseline agents | Dismissed Copilot security suggestion | Bash needed for read-only discovery operations (ls, find, wc) | 2025-12-22 |
+
+---
+
+## Documentation References
+
+| Title | URL | Relevance |
+|-------|-----|-----------|
+| OpenCode Agent Configuration | https://opencode.ai/docs/agents | Agent file format reference |
+| OpenCode Model Selection | https://opencode.ai/docs/models | Model loading priority |
+| Context7 MCP - OpenCode | /sst/opencode | Library documentation |
+
+---
+
+## Next Steps
+
+All tasks completed. Session closed.
+
+---
+
+## GitHub Integration
+
+**Branch**: feature/remove-model-config (merged)
+**Issue**: #32 - https://github.com/cmtzco/context-harness/issues/32 (closed)
+**PR**: #33 - https://github.com/cmtzco/context-harness/pull/33 (merged)
+
+---
+
+## Completed This Session
+
+<details>
+<summary>Archived Work (Expand to view)</summary>
+
+### Task: Remove hardcoded model config (Completed & Merged 2025-12-22)
+
+**Summary**: 
+- Researched OpenCode documentation via @research-subagent
+- Confirmed `model` field is optional in agent frontmatter
+- Removed model from all 16 agent files (8 root + 8 templates)
+- Added Model Configuration section to DOCS.md
+- Created GitHub issue #32
+- Created PR #33
+- Addressed Copilot review:
+  - ✅ Accepted: Fixed model identifier consistency (claude-opus-4 → claude-opus-4-20250514)
+  - ❌ Dismissed: bash:true security concerns (intentional for read-only operations)
+- PR merged to main
+
+**Files Changed**: 16 agent files + DOCS.md
+
+**Commits**:
+1. `feat: make agents model-agnostic by removing hardcoded model config`
+2. `docs: fix model identifier consistency in examples`
+
+</details>
+
+---
+
+## Notes
+
+Research completed via @research-subagent confirmed:
+- The `model` field is OPTIONAL in OpenCode agent files
+- When omitted, agents inherit from `opencode.json` default
+- Users can override per-agent via `agent.{name}.model` in JSON config
+- This makes the framework provider-neutral and more portable
+
+Model loading priority order:
+1. Command-line flag (`--model`)
+2. Agent-specific config in JSON
+3. Default model in `opencode.json`
+4. Last used model
+5. Internal priority (first available)
+
+---
+
+_Session completed and merged to main on 2025-12-22_


### PR DESCRIPTION
## Summary

Updates the SESSION.md file for the `remove-model-config` session to reflect that PR #33 has been merged.

## Changes

- Mark session status as ✅ Merged
- Update all file statuses to ✅ Merged
- Add Copilot review decision to decisions table (kept bash:true for baseline agents)
- Update GitHub integration section with closed/merged links
- Archive completed work with commit details
- Mark session as closed

This is a housekeeping PR to keep session files accurate.