### PR TITLE
feat(skills): add skill-creator with Context7 integration

### DIFF
--- a/src/context_harness/installer.py
+++ b/src/context_harness/installer.py
@@ -40,6 +40,13 @@ REQUIRED_TEMPLATE_FILES = [
     ".opencode/command/issue.md",
     ".opencode/command/pr.md",
     ".opencode/command/baseline.md",
+    # Skill: skill-creator (for deriving project-specific skills)
+    ".opencode/skill/skill-creator/SKILL.md",
+    ".opencode/skill/skill-creator/references/workflows.md",
+    ".opencode/skill/skill-creator/references/output-patterns.md",
+    ".opencode/skill/skill-creator/scripts/init_skill.py",
+    ".opencode/skill/skill-creator/scripts/package_skill.py",
+    ".opencode/skill/skill-creator/scripts/quick_validate.py",
 ]
 
 
@@ -120,7 +127,7 @@ def install_framework(
         if opencode_source.exists():
             if not quiet:
                 console.print(
-                    "[dim]Updating .opencode/agent/ and .opencode/command/ ...[/dim]"
+                    "[dim]Updating .opencode/agent/, .opencode/command/, and .opencode/skill/ ...[/dim]"
                 )
             if opencode_target.exists() and force:
                 shutil.rmtree(opencode_target)
@@ -231,6 +238,13 @@ def verify_installation(target: str) -> bool:
         ".opencode/command/issue.md",
         ".opencode/command/pr.md",
         ".opencode/command/baseline.md",
+        # Skill: skill-creator
+        ".opencode/skill/skill-creator/SKILL.md",
+        ".opencode/skill/skill-creator/references/workflows.md",
+        ".opencode/skill/skill-creator/references/output-patterns.md",
+        ".opencode/skill/skill-creator/scripts/init_skill.py",
+        ".opencode/skill/skill-creator/scripts/package_skill.py",
+        ".opencode/skill/skill-creator/scripts/quick_validate.py",
     ]
 
     for file_path in expected_files:

--- a/src/context_harness/templates/.opencode/skill/skill-creator/SKILL.md
+++ b/src/context_harness/templates/.opencode/skill/skill-creator/SKILL.md
@@ -1,0 +1,471 @@
+---
+name: skill-creator
+description: Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabilities with specialized knowledge, workflows, or tool integrations. ALWAYS use Context7 MCP to pull relevant documentation when creating skills.
+license: Based on Anthropic's skill-creator (MIT) - see LICENSE.txt
+---
+
+# Skill Creator
+
+This skill provides guidance for creating effective skills with Context7 integration.
+
+## CRITICAL: Context7 Integration Requirement
+
+**Before creating any skill, you MUST use Context7 MCP to pull relevant documentation:**
+
+```
+1. IDENTIFY the domain/technology the skill covers
+2. RESOLVE the library ID using context7_resolve-library-id
+3. FETCH relevant documentation using context7_get-library-docs
+4. USE the documentation to ensure accuracy in:
+   - API references
+   - Best practices
+   - Code examples
+   - Current syntax and patterns
+```
+
+**Example Context7 Usage:**
+
+```markdown
+When creating a "react-forms" skill:
+
+1. @context7 resolve-library-id "react"
+   → Gets /facebook/react or /vercel/next.js
+
+2. @context7 get-library-docs /facebook/react --topic "forms"
+   → Gets current form handling documentation
+
+3. Use this documentation to write accurate skill content
+```
+
+This ensures skills are grounded in real, up-to-date documentation rather than potentially outdated training data.
+
+## About Skills
+
+Skills are modular, self-contained packages that extend Claude's capabilities by providing
+specialized knowledge, workflows, and tools. Think of them as "onboarding guides" for specific
+domains or tasks—they transform Claude from a general-purpose agent into a specialized agent
+equipped with procedural knowledge that no model can fully possess.
+
+### What Skills Provide
+
+1. Specialized workflows - Multi-step procedures for specific domains
+2. Tool integrations - Instructions for working with specific file formats or APIs
+3. Domain expertise - Company-specific knowledge, schemas, business logic
+4. Bundled resources - Scripts, references, and assets for complex and repetitive tasks
+
+## Core Principles
+
+### Concise is Key
+
+The context window is a public good. Skills share the context window with everything else Claude needs: system prompt, conversation history, other Skills' metadata, and the actual user request.
+
+**Default assumption: Claude is already very smart.** Only add context Claude doesn't already have. Challenge each piece of information: "Does Claude really need this explanation?" and "Does this paragraph justify its token cost?"
+
+Prefer concise examples over verbose explanations.
+
+### Set Appropriate Degrees of Freedom
+
+Match the level of specificity to the task's fragility and variability:
+
+**High freedom (text-based instructions)**: Use when multiple approaches are valid, decisions depend on context, or heuristics guide the approach.
+
+**Medium freedom (pseudocode or scripts with parameters)**: Use when a preferred pattern exists, some variation is acceptable, or configuration affects behavior.
+
+**Low freedom (specific scripts, few parameters)**: Use when operations are fragile and error-prone, consistency is critical, or a specific sequence must be followed.
+
+Think of Claude as exploring a path: a narrow bridge with cliffs needs specific guardrails (low freedom), while an open field allows many routes (high freedom).
+
+### Anatomy of a Skill
+
+Every skill consists of a required SKILL.md file and optional bundled resources:
+
+```
+skill-name/
+├── SKILL.md (required)
+│   ├── YAML frontmatter metadata (required)
+│   │   ├── name: (required)
+│   │   └── description: (required)
+│   └── Markdown instructions (required)
+└── Bundled Resources (optional)
+    ├── scripts/          - Executable code (Python/Bash/etc.)
+    ├── references/       - Documentation intended to be loaded into context as needed
+    └── assets/           - Files used in output (templates, icons, fonts, etc.)
+```
+
+#### SKILL.md (required)
+
+Every SKILL.md consists of:
+
+- **Frontmatter** (YAML): Contains `name` and `description` fields. These are the only fields that Claude reads to determine when the skill gets used, thus it is very important to be clear and comprehensive in describing what the skill is, and when it should be used.
+- **Body** (Markdown): Instructions and guidance for using the skill. Only loaded AFTER the skill triggers (if at all).
+
+#### Bundled Resources (optional)
+
+##### Scripts (`scripts/`)
+
+Executable code (Python/Bash/etc.) for tasks that require deterministic reliability or are repeatedly rewritten.
+
+- **When to include**: When the same code is being rewritten repeatedly or deterministic reliability is needed
+- **Example**: `scripts/rotate_pdf.py` for PDF rotation tasks
+- **Benefits**: Token efficient, deterministic, may be executed without loading into context
+- **Note**: Scripts may still need to be read by Claude for patching or environment-specific adjustments
+
+##### References (`references/`)
+
+Documentation and reference material intended to be loaded as needed into context to inform Claude's process and thinking.
+
+- **When to include**: For documentation that Claude should reference while working
+- **Examples**: `references/finance.md` for financial schemas, `references/mnda.md` for company NDA template, `references/policies.md` for company policies, `references/api_docs.md` for API specifications
+- **Use cases**: Database schemas, API documentation, domain knowledge, company policies, detailed workflow guides
+- **Benefits**: Keeps SKILL.md lean, loaded only when Claude determines it's needed
+- **Best practice**: If files are large (>10k words), include grep search patterns in SKILL.md
+- **Avoid duplication**: Information should live in either SKILL.md or references files, not both. Prefer references files for detailed information unless it's truly core to the skill—this keeps SKILL.md lean while making information discoverable without hogging the context window. Keep only essential procedural instructions and workflow guidance in SKILL.md; move detailed reference material, schemas, and examples to references files.
+
+##### Assets (`assets/`)
+
+Files not intended to be loaded into context, but rather used within the output Claude produces.
+
+- **When to include**: When the skill needs files that will be used in the final output
+- **Examples**: `assets/logo.png` for brand assets, `assets/slides.pptx` for PowerPoint templates, `assets/frontend-template/` for HTML/React boilerplate, `assets/font.ttf` for typography
+- **Use cases**: Templates, images, icons, boilerplate code, fonts, sample documents that get copied or modified
+- **Benefits**: Separates output resources from documentation, enables Claude to use files without loading them into context
+
+#### What to Not Include in a Skill
+
+A skill should only contain essential files that directly support its functionality. Do NOT create extraneous documentation or auxiliary files, including:
+
+- README.md
+- INSTALLATION_GUIDE.md
+- QUICK_REFERENCE.md
+- CHANGELOG.md
+- etc.
+
+The skill should only contain the information needed for an AI agent to do the job at hand. It should not contain auxilary context about the process that went into creating it, setup and testing procedures, user-facing documentation, etc. Creating additional documentation files just adds clutter and confusion.
+
+### Progressive Disclosure Design Principle
+
+Skills use a three-level loading system to manage context efficiently:
+
+1. **Metadata (name + description)** - Always in context (~100 words)
+2. **SKILL.md body** - When skill triggers (<5k words)
+3. **Bundled resources** - As needed by Claude (Unlimited because scripts can be executed without reading into context window)
+
+#### Progressive Disclosure Patterns
+
+Keep SKILL.md body to the essentials and under 500 lines to minimize context bloat. Split content into separate files when approaching this limit. When splitting out content into other files, it is very important to reference them from SKILL.md and describe clearly when to read them, to ensure the reader of the skill knows they exist and when to use them.
+
+**Key principle:** When a skill supports multiple variations, frameworks, or options, keep only the core workflow and selection guidance in SKILL.md. Move variant-specific details (patterns, examples, configuration) into separate reference files.
+
+**Pattern 1: High-level guide with references**
+
+```markdown
+# PDF Processing
+
+## Quick start
+
+Extract text with pdfplumber:
+[code example]
+
+## Advanced features
+
+- **Form filling**: See [FORMS.md](FORMS.md) for complete guide
+- **API reference**: See [REFERENCE.md](REFERENCE.md) for all methods
+- **Examples**: See [EXAMPLES.md](EXAMPLES.md) for common patterns
+```
+
+Claude loads FORMS.md, REFERENCE.md, or EXAMPLES.md only when needed.
+
+**Pattern 2: Domain-specific organization**
+
+For Skills with multiple domains, organize content by domain to avoid loading irrelevant context:
+
+```
+bigquery-skill/
+├── SKILL.md (overview and navigation)
+└── reference/
+    ├── finance.md (revenue, billing metrics)
+    ├── sales.md (opportunities, pipeline)
+    ├── product.md (API usage, features)
+    └── marketing.md (campaigns, attribution)
+```
+
+When a user asks about sales metrics, Claude only reads sales.md.
+
+Similarly, for skills supporting multiple frameworks or variants, organize by variant:
+
+```
+cloud-deploy/
+├── SKILL.md (workflow + provider selection)
+└── references/
+    ├── aws.md (AWS deployment patterns)
+    ├── gcp.md (GCP deployment patterns)
+    └── azure.md (Azure deployment patterns)
+```
+
+When the user chooses AWS, Claude only reads aws.md.
+
+**Pattern 3: Conditional details**
+
+Show basic content, link to advanced content:
+
+```markdown
+# DOCX Processing
+
+## Creating documents
+
+Use docx-js for new documents. See [DOCX-JS.md](DOCX-JS.md).
+
+## Editing documents
+
+For simple edits, modify the XML directly.
+
+**For tracked changes**: See [REDLINING.md](REDLINING.md)
+**For OOXML details**: See [OOXML.md](OOXML.md)
+```
+
+Claude reads REDLINING.md or OOXML.md only when the user needs those features.
+
+**Important guidelines:**
+
+- **Avoid deeply nested references** - Keep references one level deep from SKILL.md. All reference files should link directly from SKILL.md.
+- **Structure longer reference files** - For files longer than 100 lines, include a table of contents at the top so Claude can see the full scope when previewing.
+
+## Skill Creation Process
+
+Skill creation involves these steps:
+
+1. Understand the skill with concrete examples
+2. **Use Context7 to research the domain** (NEW)
+3. Plan reusable skill contents (scripts, references, assets)
+4. Initialize the skill (run init_skill.py)
+5. Edit the skill (implement resources and write SKILL.md)
+6. Package the skill (run package_skill.py)
+7. Iterate based on real usage
+
+Follow these steps in order, skipping only if there is a clear reason why they are not applicable.
+
+### Step 1: Understanding the Skill with Concrete Examples
+
+Skip this step only when the skill's usage patterns are already clearly understood. It remains valuable even when working with an existing skill.
+
+To create an effective skill, clearly understand concrete examples of how the skill will be used. This understanding can come from either direct user examples or generated examples that are validated with user feedback.
+
+For example, when building an image-editor skill, relevant questions include:
+
+- "What functionality should the image-editor skill support? Editing, rotating, anything else?"
+- "Can you give some examples of how this skill would be used?"
+- "I can imagine users asking for things like 'Remove the red-eye from this image' or 'Rotate this image'. Are there other ways you imagine this skill being used?"
+- "What would a user say that should trigger this skill?"
+
+To avoid overwhelming users, avoid asking too many questions in a single message. Start with the most important questions and follow up as needed for better effectiveness.
+
+Conclude this step when there is a clear sense of the functionality the skill should support.
+
+### Step 2: Research with Context7 (NEW - MANDATORY)
+
+**Before planning or implementing any skill, gather accurate documentation:**
+
+```
+1. IDENTIFY key technologies/libraries the skill will use
+2. For EACH technology:
+   a. context7_resolve-library-id "{technology}"
+   b. context7_get-library-docs {library-id} --topic "{relevant-topic}"
+3. EXTRACT key information:
+   - Current API patterns
+   - Best practices
+   - Common pitfalls
+   - Code examples
+4. NOTE version-specific considerations
+```
+
+**Example for a "nextjs-auth" skill:**
+
+```
+1. Resolve: "next.js" → /vercel/next.js
+2. Fetch: context7_get-library-docs /vercel/next.js --topic "authentication"
+3. Resolve: "next-auth" → /nextauthjs/next-auth
+4. Fetch: context7_get-library-docs /nextauthjs/next-auth --topic "configuration"
+5. Extract: Current session handling, provider setup, middleware patterns
+```
+
+This step ensures your skill contains accurate, up-to-date information rather than potentially outdated training data.
+
+### Step 3: Planning the Reusable Skill Contents
+
+To turn concrete examples into an effective skill, analyze each example by:
+
+1. Considering how to execute on the example from scratch
+2. Identifying what scripts, references, and assets would be helpful when executing these workflows repeatedly
+
+Example: When building a `pdf-editor` skill to handle queries like "Help me rotate this PDF," the analysis shows:
+
+1. Rotating a PDF requires re-writing the same code each time
+2. A `scripts/rotate_pdf.py` script would be helpful to store in the skill
+
+Example: When designing a `frontend-webapp-builder` skill for queries like "Build me a todo app" or "Build me a dashboard to track my steps," the analysis shows:
+
+1. Writing a frontend webapp requires the same boilerplate HTML/React each time
+2. An `assets/hello-world/` template containing the boilerplate HTML/React project files would be helpful to store in the skill
+
+Example: When building a `big-query` skill to handle queries like "How many users have logged in today?" the analysis shows:
+
+1. Querying BigQuery requires re-discovering the table schemas and relationships each time
+2. A `references/schema.md` file documenting the table schemas would be helpful to store in the skill
+
+To establish the skill's contents, analyze each concrete examples to create a list of the reusable resources to include: scripts, references, and assets.
+
+### Step 4: Initializing the Skill
+
+At this point, it is time to actually create the skill.
+
+Skip this step only if the skill being developed already exists, and iteration or packaging is needed. In this case, continue to the next step.
+
+When creating a new skill from scratch, always run the `init_skill.py` script. The script conveniently generates a new template skill directory that automatically includes everything a skill requires, making the skill creation process much more efficient and reliable.
+
+Usage:
+
+```bash
+scripts/init_skill.py <skill-name> --path <output-directory>
+```
+
+The script:
+
+- Creates the skill directory at the specified path
+- Generates a SKILL.md template with proper frontmatter and TODO placeholders
+- Creates example resource directories: `scripts/`, `references/`, and `assets/`
+- Adds example files in each directory that can be customized or deleted
+
+After initialization, customize or remove the generated SKILL.md and example files as needed.
+
+### Step 5: Edit the Skill
+
+When editing the (newly-generated or existing) skill, remember that the skill is being created for another instance of Claude to use. Include information that would be beneficial and non-obvious to Claude. Consider what procedural knowledge, domain-specific details, or reusable assets would help another Claude instance execute these tasks more effectively.
+
+#### Learn Proven Design Patterns
+
+Consult these helpful guides based on your skill's needs:
+
+- **Multi-step processes**: See references/workflows.md for sequential workflows and conditional logic
+- **Specific output formats or quality standards**: See references/output-patterns.md for template and example patterns
+
+These files contain established best practices for effective skill design.
+
+#### Incorporate Context7 Research
+
+When writing the SKILL.md:
+
+1. **Reference accurate APIs**: Use the patterns and syntax from Context7 documentation
+2. **Include version notes**: If the documentation is version-specific, note it
+3. **Link to sources**: When appropriate, reference official documentation URLs
+4. **Update examples**: Ensure code examples match current library versions
+
+#### Start with Reusable Skill Contents
+
+To begin implementation, start with the reusable resources identified above: `scripts/`, `references/`, and `assets/` files. Note that this step may require user input. For example, when implementing a `brand-guidelines` skill, the user may need to provide brand assets or templates to store in `assets/`, or documentation to store in `references/`.
+
+Added scripts must be tested by actually running them to ensure there are no bugs and that the output matches what is expected. If there are many similar scripts, only a representative sample needs to be tested to ensure confidence that they all work while balancing time to completion.
+
+Any example files and directories not needed for the skill should be deleted. The initialization script creates example files in `scripts/`, `references/`, and `assets/` to demonstrate structure, but most skills won't need all of them.
+
+#### Update SKILL.md
+
+**Writing Guidelines:** Always use imperative/infinitive form.
+
+##### Frontmatter
+
+Write the YAML frontmatter with `name` and `description`:
+
+- `name`: The skill name
+- `description`: This is the primary triggering mechanism for your skill, and helps Claude understand when to use the skill.
+  - Include both what the Skill does and specific triggers/contexts for when to use it.
+  - Include all "when to use" information here - Not in the body. The body is only loaded after triggering, so "When to Use This Skill" sections in the body are not helpful to Claude.
+  - Example description for a `docx` skill: "Comprehensive document creation, editing, and analysis with support for tracked changes, comments, formatting preservation, and text extraction. Use when Claude needs to work with professional documents (.docx files) for: (1) Creating new documents, (2) Modifying or editing content, (3) Working with tracked changes, (4) Adding comments, or any other document tasks"
+
+Do not include any other fields in YAML frontmatter.
+
+##### Body
+
+Write instructions for using the skill and its bundled resources.
+
+### Step 6: Packaging a Skill
+
+Once development of the skill is complete, it must be packaged into a distributable .skill file that gets shared with the user. The packaging process automatically validates the skill first to ensure it meets all requirements:
+
+```bash
+scripts/package_skill.py <path/to/skill-folder>
+```
+
+Optional output directory specification:
+
+```bash
+scripts/package_skill.py <path/to/skill-folder> ./dist
+```
+
+The packaging script will:
+
+1. **Validate** the skill automatically, checking:
+
+   - YAML frontmatter format and required fields
+   - Skill naming conventions and directory structure
+   - Description completeness and quality
+   - File organization and resource references
+
+2. **Package** the skill if validation passes, creating a .skill file named after the skill (e.g., `my-skill.skill`) that includes all files and maintains the proper directory structure for distribution. The .skill file is a zip file with a .skill extension.
+
+If validation fails, the script will report the errors and exit without creating a package. Fix any validation errors and run the packaging command again.
+
+### Step 7: Iterate
+
+After testing the skill, users may request improvements. Often this happens right after using the skill, with fresh context of how the skill performed.
+
+**Iteration workflow:**
+
+1. Use the skill on real tasks
+2. Notice struggles or inefficiencies
+3. Identify how SKILL.md or bundled resources should be updated
+4. **Re-check Context7** if APIs or patterns have changed
+5. Implement changes and test again
+
+## Context7 Quick Reference
+
+### When to Use Context7
+
+| Scenario | Action |
+|----------|--------|
+| Creating new skill | ALWAYS use Context7 for domain research |
+| Updating existing skill | Check if APIs/patterns have changed |
+| Adding code examples | Verify syntax with Context7 docs |
+| Unsure about best practices | Fetch documentation for guidance |
+
+### Context7 Commands
+
+```
+# Resolve a library name to ID
+context7_resolve-library-id "react"
+context7_resolve-library-id "tailwindcss"
+context7_resolve-library-id "postgresql"
+
+# Fetch documentation
+context7_get-library-docs /facebook/react --topic "hooks"
+context7_get-library-docs /tailwindlabs/tailwindcss --topic "configuration"
+context7_get-library-docs /postgres/postgres --mode "info"
+
+# Modes
+--mode "code"  # API references and code examples (default)
+--mode "info"  # Conceptual guides and architecture
+```
+
+### Common Library IDs
+
+| Technology | Library ID |
+|------------|-----------|
+| React | /facebook/react |
+| Next.js | /vercel/next.js |
+| Vue | /vuejs/vue |
+| Tailwind CSS | /tailwindlabs/tailwindcss |
+| TypeScript | /microsoft/typescript |
+| Node.js | /nodejs/node |
+| Python | /python/cpython |
+| PostgreSQL | /postgres/postgres |
+
+Always verify with `resolve-library-id` as IDs may change.

--- a/src/context_harness/templates/.opencode/skill/skill-creator/references/output-patterns.md
+++ b/src/context_harness/templates/.opencode/skill/skill-creator/references/output-patterns.md
@@ -1,0 +1,225 @@
+# Output Patterns
+
+Use these patterns when skills need to produce consistent, high-quality output.
+
+## Template Pattern
+
+Provide templates for output format. Match the level of strictness to your needs.
+
+**For strict requirements (like API responses or data formats):**
+
+```markdown
+## Report structure
+
+ALWAYS use this exact template structure:
+
+# [Analysis Title]
+
+## Executive summary
+[One-paragraph overview of key findings]
+
+## Key findings
+- Finding 1 with supporting data
+- Finding 2 with supporting data
+- Finding 3 with supporting data
+
+## Recommendations
+1. Specific actionable recommendation
+2. Specific actionable recommendation
+```
+
+**For flexible guidance (when adaptation is useful):**
+
+```markdown
+## Report structure
+
+Here is a sensible default format, but use your best judgment:
+
+# [Analysis Title]
+
+## Executive summary
+[Overview]
+
+## Key findings
+[Adapt sections based on what you discover]
+
+## Recommendations
+[Tailor to the specific context]
+
+Adjust sections as needed for the specific analysis type.
+```
+
+## Examples Pattern
+
+For skills where output quality depends on seeing examples, provide input/output pairs:
+
+```markdown
+## Commit message format
+
+Generate commit messages following these examples:
+
+**Example 1:**
+Input: Added user authentication with JWT tokens
+Output:
+```
+feat(auth): implement JWT-based authentication
+
+Add login endpoint and token validation middleware
+```
+
+**Example 2:**
+Input: Fixed bug where dates displayed incorrectly in reports
+Output:
+```
+fix(reports): correct date formatting in timezone conversion
+
+Use UTC timestamps consistently across report generation
+```
+
+Follow this style: type(scope): brief description, then detailed explanation.
+```
+
+Examples help Claude understand the desired style and level of detail more clearly than descriptions alone.
+
+## Code Output Patterns
+
+### Minimal Example Pattern
+
+Show the simplest possible working code:
+
+```markdown
+## Quick Start
+
+```python
+from mylib import Client
+
+client = Client()
+result = client.do_thing("input")
+print(result)
+```
+
+For advanced options, see references/advanced.md
+```
+
+### Progressive Complexity Pattern
+
+Start simple, add complexity only when needed:
+
+```markdown
+## Usage Levels
+
+### Basic (most users)
+```python
+result = process(data)
+```
+
+### With Options
+```python
+result = process(data, format="json", validate=True)
+```
+
+### Full Control
+```python
+result = process(
+    data,
+    format="json",
+    validate=True,
+    hooks={
+        "pre": my_preprocessor,
+        "post": my_postprocessor
+    },
+    config=custom_config
+)
+```
+
+## Validation Patterns
+
+### Checklist Pattern
+
+For outputs that must meet criteria:
+
+```markdown
+## Before Submitting
+
+Verify your output against this checklist:
+
+- [ ] All required fields present
+- [ ] Dates in ISO 8601 format
+- [ ] No PII in public fields
+- [ ] Total under 10MB
+- [ ] Valid JSON/YAML syntax
+```
+
+### Assertion Pattern
+
+For programmatic validation:
+
+```markdown
+## Output Validation
+
+Run the validator before using output:
+
+```bash
+scripts/validate_output.py output.json
+```
+
+Expected: "✅ Output valid"
+
+Common errors:
+- "Missing field: X" → Add required field X
+- "Invalid date format" → Use YYYY-MM-DD
+```
+
+## Grounding Outputs with Context7
+
+When skill outputs involve library-specific formats or patterns:
+
+```markdown
+## API Response Format
+
+**First, verify current format with Context7:**
+```
+context7_get-library-docs /api/library --topic "response format"
+```
+
+**Then format output accordingly:**
+
+Based on current documentation, responses should follow:
+[Insert pattern from documentation]
+
+**Note:** API response formats may change between versions.
+Always verify against current documentation.
+```
+
+## Consistency Patterns
+
+### Naming Convention Pattern
+
+```markdown
+## Naming Conventions
+
+| Item | Convention | Example |
+|------|------------|---------|
+| Files | kebab-case | `user-profile.ts` |
+| Classes | PascalCase | `UserProfile` |
+| Functions | camelCase | `getUserProfile` |
+| Constants | SCREAMING_SNAKE | `MAX_RETRIES` |
+| Database tables | snake_case | `user_profiles` |
+```
+
+### Style Guide Pattern
+
+```markdown
+## Code Style
+
+- Indent: 2 spaces
+- Line length: 80 characters max
+- Quotes: Single quotes for strings
+- Semicolons: Required
+- Trailing commas: Always in multiline
+
+Run formatter before committing:
+```bash
+npm run format
+```
+```

--- a/src/context_harness/templates/.opencode/skill/skill-creator/references/workflows.md
+++ b/src/context_harness/templates/.opencode/skill/skill-creator/references/workflows.md
@@ -1,0 +1,111 @@
+# Workflow Patterns
+
+## Sequential Workflows
+
+For complex tasks, break operations into clear, sequential steps. It is often helpful to give Claude an overview of the process towards the beginning of SKILL.md:
+
+```markdown
+Filling a PDF form involves these steps:
+
+1. Analyze the form (run analyze_form.py)
+2. Create field mapping (edit fields.json)
+3. Validate mapping (run validate_fields.py)
+4. Fill the form (run fill_form.py)
+5. Verify output (run verify_output.py)
+```
+
+## Conditional Workflows
+
+For tasks with branching logic, guide Claude through decision points:
+
+```markdown
+1. Determine the modification type:
+   **Creating new content?** → Follow "Creation workflow" below
+   **Editing existing content?** → Follow "Editing workflow" below
+
+2. Creation workflow: [steps]
+3. Editing workflow: [steps]
+```
+
+## Decision Trees
+
+For complex branching with multiple paths:
+
+```markdown
+## Workflow Decision Tree
+
+Start here and follow the arrows:
+
+┌─────────────────────────────────┐
+│ What type of document?          │
+└────────────┬────────────────────┘
+             │
+    ┌────────┴────────┐
+    ▼                 ▼
+┌────────┐      ┌────────┐
+│  PDF   │      │  DOCX  │
+└───┬────┘      └───┬────┘
+    │               │
+    ▼               ▼
+[PDF flow]    [DOCX flow]
+```
+
+## Error Recovery Workflows
+
+For fragile operations, include explicit error handling:
+
+```markdown
+## Image Processing Workflow
+
+1. Load image
+   - **If format unsupported**: Convert using ImageMagick first
+   - **If corrupted**: Report error, suggest alternative source
+
+2. Apply transformations
+   - **If memory error**: Reduce resolution, retry
+   - **If timeout**: Split into smaller operations
+
+3. Save output
+   - **If disk full**: Clean temp files, retry
+   - **If permission denied**: Suggest alternative path
+```
+
+## Parallel vs Sequential
+
+Indicate when steps can be parallelized:
+
+```markdown
+## Data Processing Workflow
+
+### Sequential (order matters):
+1. Validate input schema
+2. Transform data
+3. Write to database
+
+### Parallel (can run simultaneously):
+- Generate thumbnails
+- Extract metadata
+- Calculate checksums
+```
+
+## Context7 Integration in Workflows
+
+When workflows involve external APIs or libraries, include Context7 lookup steps:
+
+```markdown
+## API Integration Workflow
+
+1. **Research Phase** (Context7):
+   - Resolve library: `context7_resolve-library-id "{api-name}"`
+   - Fetch docs: `context7_get-library-docs {id} --topic "{relevant-topic}"`
+   - Note current patterns and any deprecations
+
+2. **Implementation Phase**:
+   - Apply patterns from documentation
+   - Use current API syntax
+   - Follow documented best practices
+
+3. **Validation Phase**:
+   - Test against documented behavior
+   - Verify error handling matches docs
+```

--- a/src/context_harness/templates/.opencode/skill/skill-creator/scripts/init_skill.py
+++ b/src/context_harness/templates/.opencode/skill/skill-creator/scripts/init_skill.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""
+Skill Initializer - Creates a new skill from template
+
+Usage:
+    init_skill.py <skill-name> --path <path>
+
+Examples:
+    init_skill.py my-new-skill --path skills/public
+    init_skill.py my-api-helper --path skills/private
+    init_skill.py custom-skill --path /custom/location
+"""
+
+import sys
+from pathlib import Path
+
+
+SKILL_TEMPLATE = """---
+name: {skill_name}
+description: [TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]
+---
+
+# {skill_title}
+
+## CRITICAL: Context7 Research Required
+
+**Before implementing this skill, use Context7 to research the domain:**
+
+```
+1. context7_resolve-library-id "{{relevant-library}}"
+2. context7_get-library-docs {{library-id}} --topic "{{relevant-topic}}"
+3. Use documentation to ensure accuracy
+```
+
+## Overview
+
+[TODO: 1-2 sentences explaining what this skill enables]
+
+## Structuring This Skill
+
+[TODO: Choose the structure that best fits this skill's purpose. Common patterns:
+
+**1. Workflow-Based** (best for sequential processes)
+- Works well when there are clear step-by-step procedures
+- Example: DOCX skill with "Workflow Decision Tree" → "Reading" → "Creating" → "Editing"
+- Structure: ## Overview → ## Workflow Decision Tree → ## Step 1 → ## Step 2...
+
+**2. Task-Based** (best for tool collections)
+- Works well when the skill offers different operations/capabilities
+- Example: PDF skill with "Quick Start" → "Merge PDFs" → "Split PDFs" → "Extract Text"
+- Structure: ## Overview → ## Quick Start → ## Task Category 1 → ## Task Category 2...
+
+**3. Reference/Guidelines** (best for standards or specifications)
+- Works well for brand guidelines, coding standards, or requirements
+- Example: Brand styling with "Brand Guidelines" → "Colors" → "Typography" → "Features"
+- Structure: ## Overview → ## Guidelines → ## Specifications → ## Usage...
+
+**4. Capabilities-Based** (best for integrated systems)
+- Works well when the skill provides multiple interrelated features
+- Example: Product Management with "Core Capabilities" → numbered capability list
+- Structure: ## Overview → ## Core Capabilities → ### 1. Feature → ### 2. Feature...
+
+Patterns can be mixed and matched as needed. Most skills combine patterns (e.g., start with task-based, add workflow for complex operations).
+
+Delete this entire "Structuring This Skill" section when done - it's just guidance.]
+
+## [TODO: Replace with the first main section based on chosen structure]
+
+[TODO: Add content here. See examples in existing skills:
+- Code samples for technical skills
+- Decision trees for complex workflows
+- Concrete examples with realistic user requests
+- References to scripts/templates/references as needed]
+
+## Resources
+
+This skill includes example resource directories that demonstrate how to organize different types of bundled resources:
+
+### scripts/
+Executable code (Python/Bash/etc.) that can be run directly to perform specific operations.
+
+**Examples from other skills:**
+- PDF skill: `fill_fillable_fields.py`, `extract_form_field_info.py` - utilities for PDF manipulation
+- DOCX skill: `document.py`, `utilities.py` - Python modules for document processing
+
+**Appropriate for:** Python scripts, shell scripts, or any executable code that performs automation, data processing, or specific operations.
+
+**Note:** Scripts may be executed without loading into context, but can still be read by Claude for patching or environment adjustments.
+
+### references/
+Documentation and reference material intended to be loaded into context to inform Claude's process and thinking.
+
+**Examples from other skills:**
+- Product management: `communication.md`, `context_building.md` - detailed workflow guides
+- BigQuery: API reference documentation and query examples
+- Finance: Schema documentation, company policies
+
+**Appropriate for:** In-depth documentation, API references, database schemas, comprehensive guides, or any detailed information that Claude should reference while working.
+
+### assets/
+Files not intended to be loaded into context, but rather used within the output Claude produces.
+
+**Examples from other skills:**
+- Brand styling: PowerPoint template files (.pptx), logo files
+- Frontend builder: HTML/React boilerplate project directories
+- Typography: Font files (.ttf, .woff2)
+
+**Appropriate for:** Templates, boilerplate code, document templates, images, icons, fonts, or any files meant to be copied or used in the final output.
+
+---
+
+**Any unneeded directories can be deleted.** Not every skill requires all three types of resources.
+"""
+
+EXAMPLE_SCRIPT = '''#!/usr/bin/env python3
+"""
+Example helper script for {skill_name}
+
+This is a placeholder script that can be executed directly.
+Replace with actual implementation or delete if not needed.
+
+Example real scripts from other skills:
+- pdf/scripts/fill_fillable_fields.py - Fills PDF form fields
+- pdf/scripts/convert_pdf_to_images.py - Converts PDF pages to images
+"""
+
+def main():
+    print("This is an example script for {skill_name}")
+    # TODO: Add actual script logic here
+    # This could be data processing, file conversion, API calls, etc.
+
+if __name__ == "__main__":
+    main()
+'''
+
+EXAMPLE_REFERENCE = """# Reference Documentation for {skill_title}
+
+This is a placeholder for detailed reference documentation.
+Replace with actual reference content or delete if not needed.
+
+Example real reference docs from other skills:
+- product-management/references/communication.md - Comprehensive guide for status updates
+- product-management/references/context_building.md - Deep-dive on gathering context
+- bigquery/references/ - API references and query examples
+
+## Context7 Integration
+
+When populating this reference, use Context7 to fetch accurate documentation:
+
+```
+1. context7_resolve-library-id "{{relevant-library}}"
+2. context7_get-library-docs {{library-id}} --topic "{{topic}}"
+3. Extract and adapt relevant information
+```
+
+## When Reference Docs Are Useful
+
+Reference docs are ideal for:
+- Comprehensive API documentation
+- Detailed workflow guides
+- Complex multi-step processes
+- Information too lengthy for main SKILL.md
+- Content that's only needed for specific use cases
+
+## Structure Suggestions
+
+### API Reference Example
+- Overview
+- Authentication
+- Endpoints with examples
+- Error codes
+- Rate limits
+
+### Workflow Guide Example
+- Prerequisites
+- Step-by-step instructions
+- Common patterns
+- Troubleshooting
+- Best practices
+"""
+
+EXAMPLE_ASSET = """# Example Asset File
+
+This placeholder represents where asset files would be stored.
+Replace with actual asset files (templates, images, fonts, etc.) or delete if not needed.
+
+Asset files are NOT intended to be loaded into context, but rather used within
+the output Claude produces.
+
+Example asset files from other skills:
+- Brand guidelines: logo.png, slides_template.pptx
+- Frontend builder: hello-world/ directory with HTML/React boilerplate
+- Typography: custom-font.ttf, font-family.woff2
+- Data: sample_data.csv, test_dataset.json
+
+## Common Asset Types
+
+- Templates: .pptx, .docx, boilerplate directories
+- Images: .png, .jpg, .svg, .gif
+- Fonts: .ttf, .otf, .woff, .woff2
+- Boilerplate code: Project directories, starter files
+- Icons: .ico, .svg
+- Data files: .csv, .json, .xml, .yaml
+
+Note: This is a text placeholder. Actual assets can be any file type.
+"""
+
+
+def title_case_skill_name(skill_name):
+    """Convert hyphenated skill name to Title Case for display."""
+    return " ".join(word.capitalize() for word in skill_name.split("-"))
+
+
+def init_skill(skill_name, path):
+    """
+    Initialize a new skill directory with template SKILL.md.
+
+    Args:
+        skill_name: Name of the skill
+        path: Path where the skill directory should be created
+
+    Returns:
+        Path to created skill directory, or None if error
+    """
+    # Determine skill directory path
+    skill_dir = Path(path).resolve() / skill_name
+
+    # Check if directory already exists
+    if skill_dir.exists():
+        print(f"❌ Error: Skill directory already exists: {skill_dir}")
+        return None
+
+    # Create skill directory
+    try:
+        skill_dir.mkdir(parents=True, exist_ok=False)
+        print(f"✅ Created skill directory: {skill_dir}")
+    except Exception as e:
+        print(f"❌ Error creating directory: {e}")
+        return None
+
+    # Create SKILL.md from template
+    skill_title = title_case_skill_name(skill_name)
+    skill_content = SKILL_TEMPLATE.format(
+        skill_name=skill_name, skill_title=skill_title
+    )
+
+    skill_md_path = skill_dir / "SKILL.md"
+    try:
+        skill_md_path.write_text(skill_content)
+        print("✅ Created SKILL.md")
+    except Exception as e:
+        print(f"❌ Error creating SKILL.md: {e}")
+        return None
+
+    # Create resource directories with example files
+    try:
+        # Create scripts/ directory with example script
+        scripts_dir = skill_dir / "scripts"
+        scripts_dir.mkdir(exist_ok=True)
+        example_script = scripts_dir / "example.py"
+        example_script.write_text(EXAMPLE_SCRIPT.format(skill_name=skill_name))
+        example_script.chmod(0o755)
+        print("✅ Created scripts/example.py")
+
+        # Create references/ directory with example reference doc
+        references_dir = skill_dir / "references"
+        references_dir.mkdir(exist_ok=True)
+        example_reference = references_dir / "api_reference.md"
+        example_reference.write_text(EXAMPLE_REFERENCE.format(skill_title=skill_title))
+        print("✅ Created references/api_reference.md")
+
+        # Create assets/ directory with example asset placeholder
+        assets_dir = skill_dir / "assets"
+        assets_dir.mkdir(exist_ok=True)
+        example_asset = assets_dir / "example_asset.txt"
+        example_asset.write_text(EXAMPLE_ASSET)
+        print("✅ Created assets/example_asset.txt")
+    except Exception as e:
+        print(f"❌ Error creating resource directories: {e}")
+        return None
+
+    # Print next steps
+    print(f"\n✅ Skill '{skill_name}' initialized successfully at {skill_dir}")
+    print("\nNext steps:")
+    print("1. Use Context7 to research the domain (REQUIRED)")
+    print("2. Edit SKILL.md to complete the TODO items and update the description")
+    print(
+        "3. Customize or delete the example files in scripts/, references/, and assets/"
+    )
+    print("4. Run the validator when ready to check the skill structure")
+
+    return skill_dir
+
+
+def main():
+    if len(sys.argv) < 4 or sys.argv[2] != "--path":
+        print("Usage: init_skill.py <skill-name> --path <path>")
+        print("\nSkill name requirements:")
+        print("  - Hyphen-case identifier (e.g., 'data-analyzer')")
+        print("  - Lowercase letters, digits, and hyphens only")
+        print("  - Max 40 characters")
+        print("  - Must match directory name exactly")
+        print("\nExamples:")
+        print("  init_skill.py my-new-skill --path skills/public")
+        print("  init_skill.py my-api-helper --path skills/private")
+        print("  init_skill.py custom-skill --path /custom/location")
+        sys.exit(1)
+
+    skill_name = sys.argv[1]
+    path = sys.argv[3]
+
+    print(f"🚀 Initializing skill: {skill_name}")
+    print(f"   Location: {path}")
+    print()
+
+    result = init_skill(skill_name, path)
+
+    if result:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/context_harness/templates/.opencode/skill/skill-creator/scripts/package_skill.py
+++ b/src/context_harness/templates/.opencode/skill/skill-creator/scripts/package_skill.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Skill Packager - Creates a distributable .skill file of a skill folder
+
+Usage:
+    python package_skill.py <path/to/skill-folder> [output-directory]
+
+Example:
+    python package_skill.py skills/public/my-skill
+    python package_skill.py skills/public/my-skill ./dist
+"""
+
+import sys
+import zipfile
+from pathlib import Path
+
+# Import validate_skill from quick_validate (same directory)
+try:
+    from quick_validate import validate_skill
+except ImportError:
+    # If running from different directory, try relative import
+    import importlib.util
+
+    script_dir = Path(__file__).parent
+    spec = importlib.util.spec_from_file_location(
+        "quick_validate", script_dir / "quick_validate.py"
+    )
+    quick_validate = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(quick_validate)
+    validate_skill = quick_validate.validate_skill
+
+
+def package_skill(skill_path, output_dir=None):
+    """
+    Package a skill folder into a .skill file.
+
+    Args:
+        skill_path: Path to the skill folder
+        output_dir: Optional output directory for the .skill file (defaults to current directory)
+
+    Returns:
+        Path to the created .skill file, or None if error
+    """
+    skill_path = Path(skill_path).resolve()
+
+    # Validate skill folder exists
+    if not skill_path.exists():
+        print(f"❌ Error: Skill folder not found: {skill_path}")
+        return None
+
+    if not skill_path.is_dir():
+        print(f"❌ Error: Path is not a directory: {skill_path}")
+        return None
+
+    # Validate SKILL.md exists
+    skill_md = skill_path / "SKILL.md"
+    if not skill_md.exists():
+        print(f"❌ Error: SKILL.md not found in {skill_path}")
+        return None
+
+    # Run validation before packaging
+    print("🔍 Validating skill...")
+    valid, message = validate_skill(skill_path)
+    if not valid:
+        print(f"❌ Validation failed: {message}")
+        print("   Please fix the validation errors before packaging.")
+        return None
+    print(f"✅ {message}\n")
+
+    # Determine output location
+    skill_name = skill_path.name
+    if output_dir:
+        output_path = Path(output_dir).resolve()
+        output_path.mkdir(parents=True, exist_ok=True)
+    else:
+        output_path = Path.cwd()
+
+    skill_filename = output_path / f"{skill_name}.skill"
+
+    # Create the .skill file (zip format)
+    try:
+        with zipfile.ZipFile(skill_filename, "w", zipfile.ZIP_DEFLATED) as zipf:
+            # Walk through the skill directory
+            for file_path in skill_path.rglob("*"):
+                if file_path.is_file():
+                    # Calculate the relative path within the zip
+                    arcname = file_path.relative_to(skill_path.parent)
+                    zipf.write(file_path, arcname)
+                    print(f"  Added: {arcname}")
+
+        print(f"\n✅ Successfully packaged skill to: {skill_filename}")
+        return skill_filename
+
+    except Exception as e:
+        print(f"❌ Error creating .skill file: {e}")
+        return None
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(
+            "Usage: python package_skill.py <path/to/skill-folder> [output-directory]"
+        )
+        print("\nExample:")
+        print("  python package_skill.py skills/public/my-skill")
+        print("  python package_skill.py skills/public/my-skill ./dist")
+        sys.exit(1)
+
+    skill_path = sys.argv[1]
+    output_dir = sys.argv[2] if len(sys.argv) > 2 else None
+
+    print(f"📦 Packaging skill: {skill_path}")
+    if output_dir:
+        print(f"   Output directory: {output_dir}")
+    print()
+
+    result = package_skill(skill_path, output_dir)
+
+    if result:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/context_harness/templates/.opencode/skill/skill-creator/scripts/quick_validate.py
+++ b/src/context_harness/templates/.opencode/skill/skill-creator/scripts/quick_validate.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Quick validation script for skills - minimal version
+"""
+
+import sys
+import os
+import re
+import yaml
+from pathlib import Path
+
+
+def validate_skill(skill_path):
+    """Basic validation of a skill"""
+    skill_path = Path(skill_path)
+
+    # Check SKILL.md exists
+    skill_md = skill_path / "SKILL.md"
+    if not skill_md.exists():
+        return False, "SKILL.md not found"
+
+    # Read and validate frontmatter
+    content = skill_md.read_text()
+    if not content.startswith("---"):
+        return False, "No YAML frontmatter found"
+
+    # Extract frontmatter
+    match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+    if not match:
+        return False, "Invalid frontmatter format"
+
+    frontmatter_text = match.group(1)
+
+    # Parse YAML frontmatter
+    try:
+        frontmatter = yaml.safe_load(frontmatter_text)
+        if not isinstance(frontmatter, dict):
+            return False, "Frontmatter must be a YAML dictionary"
+    except yaml.YAMLError as e:
+        return False, f"Invalid YAML in frontmatter: {e}"
+
+    # Define allowed properties
+    ALLOWED_PROPERTIES = {"name", "description", "license", "allowed-tools", "metadata"}
+
+    # Check for unexpected properties (excluding nested keys under metadata)
+    unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
+    if unexpected_keys:
+        return False, (
+            f"Unexpected key(s) in SKILL.md frontmatter: {', '.join(sorted(unexpected_keys))}. "
+            f"Allowed properties are: {', '.join(sorted(ALLOWED_PROPERTIES))}"
+        )
+
+    # Check required fields
+    if "name" not in frontmatter:
+        return False, "Missing 'name' in frontmatter"
+    if "description" not in frontmatter:
+        return False, "Missing 'description' in frontmatter"
+
+    # Extract name for validation
+    name = frontmatter.get("name", "")
+    if not isinstance(name, str):
+        return False, f"Name must be a string, got {type(name).__name__}"
+    name = name.strip()
+    if name:
+        # Check naming convention (hyphen-case: lowercase with hyphens)
+        if not re.match(r"^[a-z0-9-]+$", name):
+            return (
+                False,
+                f"Name '{name}' should be hyphen-case (lowercase letters, digits, and hyphens only)",
+            )
+        if name.startswith("-") or name.endswith("-") or "--" in name:
+            return (
+                False,
+                f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens",
+            )
+        # Check name length (max 64 characters per spec)
+        if len(name) > 64:
+            return (
+                False,
+                f"Name is too long ({len(name)} characters). Maximum is 64 characters.",
+            )
+
+    # Extract and validate description
+    description = frontmatter.get("description", "")
+    if not isinstance(description, str):
+        return False, f"Description must be a string, got {type(description).__name__}"
+    description = description.strip()
+    if description:
+        # Check for angle brackets
+        if "<" in description or ">" in description:
+            return False, "Description cannot contain angle brackets (< or >)"
+        # Check description length (max 1024 characters per spec)
+        if len(description) > 1024:
+            return (
+                False,
+                f"Description is too long ({len(description)} characters). Maximum is 1024 characters.",
+            )
+
+    return True, "Skill is valid!"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python quick_validate.py <skill_directory>")
+        sys.exit(1)
+
+    valid, message = validate_skill(sys.argv[1])
+    print(message)
+    sys.exit(0 if valid else 1)


### PR DESCRIPTION
## Summary

Include Anthropic's skill-creator skill as a default when running `context-harness init`. This enables deriving project-specific skills during `/baseline` command execution, making it easier to work efficiently within projects.

Key enhancement: **Context7 integration** ensures skills are created with accurate, up-to-date documentation rather than potentially outdated training data.

## Changes

| File | Purpose |
|------|---------|
| `.opencode/skill/skill-creator/SKILL.md` | Main skill definition with mandatory Context7 research step |
| `.opencode/skill/skill-creator/references/workflows.md` | Workflow patterns guide |
| `.opencode/skill/skill-creator/references/output-patterns.md` | Output formatting patterns |
| `.opencode/skill/skill-creator/scripts/init_skill.py` | Initialize new skills with template |
| `.opencode/skill/skill-creator/scripts/package_skill.py` | Package skills for distribution |
| `.opencode/skill/skill-creator/scripts/quick_validate.py` | Validate skill structure |
| `src/context_harness/installer.py` | Added skill files to REQUIRED_TEMPLATE_FILES |

## Context7 Integration

When creating any skill, Claude is now required to:
1. Use `context7_resolve-library-id` to find relevant libraries
2. Fetch documentation with `context7_get-library-docs`
3. Ground skill content in real, current documentation

This is enforced through:
- A new **Step 2: Research with Context7** in the skill creation process
- Context7 Quick Reference section in SKILL.md
- Template reminders in `init_skill.py` output

## Decisions Made

| Decision | Rationale |
|----------|-----------|
| Skill location `.opencode/skill/` | Follows OpenCode convention for skills |
| Context7 mandatory | Ensures skills have accurate, grounded documentation |
| Executable scripts | Allows direct execution with `./script.py` |

## Testing

- ✅ Template validation passes (0 missing files)
- ✅ All 26 existing tests pass

## Related

- Closes #35

## Documentation

- Source: [Anthropic skill-creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator)
- Context7 MCP for documentation lookup

---

_Created via ContextHarness session: skills_