### PR TITLE
docs(readme): restructure with quickstart-first approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ uv tool install "git+https://github.com/co-labs-co/context-harness.git"
 context-harness init
 
 # Open OpenCode and start working
+/baseline              # Analyze project (first time)
 /ctx my-feature        # Create session + branch
 # ... do your work ...
 /compact               # Save context


### PR DESCRIPTION
## Summary

- Restructure README with quickstart at the very top for <30 second onboarding
- Add comprehensive command reference tables organized by category (Session, GitHub, Analysis, CLI)

## Changes

**Before**: Installation instructions mixed with usage, scattered command documentation

**After**:
1. **Quickstart** (5 lines) - Get started immediately
2. **Commands Reference** - All slash commands with examples
3. **CLI Reference** - All `context-harness` subcommands
4. **How It Works** - SESSION.md explanation + typical workflow
5. **Requirements/Docs/License** - Supporting info at bottom

## Why

New users should be able to:
- Install and start using ContextHarness in under 30 seconds
- Find any command quickly via organized tables
- Dive deeper only when needed