### PR TITLE
feat(cli): add configurable skills registry with layered precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,131 @@ context-harness skill extract <name>    # Share a specific local skill
    fastapi-crud - FastAPI CRUD patterns
 ```
 
+### Configuration Management
+
+```bash
+context-harness config list                    # Show all configuration
+context-harness config get skills-repo         # Get skills repository
+context-harness config set skills-repo <repo>  # Set project-level skills repo
+context-harness config set skills-repo <repo> --user  # Set user-level default
+context-harness config unset skills-repo       # Remove project-level setting
+```
+
+---
+
+## Custom Skills Repository
+
+You can configure a custom skills repository (e.g., your organization's private skills repo or a personal fork).
+
+### Configuration Precedence
+
+ContextHarness resolves the skills repository in this order:
+
+| Priority | Source | Location | Use Case |
+|----------|--------|----------|----------|
+| 1 (Highest) | Environment Variable | `CONTEXT_HARNESS_SKILLS_REPO` | CI/CD, temporary overrides |
+| 2 | Project Config | `opencode.json` → `skillsRegistry.default` | Per-project custom repo |
+| 3 | User Config | `~/.context-harness/config.json` | Personal default |
+| 4 (Lowest) | Default | Hardcoded | Official skills repository |
+
+### Setting a Custom Skills Repository
+
+You can specify the repository using either the short `owner/repo` format or the full GitHub URL:
+
+```bash
+# Short format
+context-harness config set skills-repo my-org/my-skills-repo
+
+# Full GitHub URL (automatically normalized to owner/repo)
+context-harness config set skills-repo https://github.com/my-org/my-skills-repo
+```
+
+**Project-level** (for team/project-specific repos):
+```bash
+context-harness config set skills-repo my-org/my-skills-repo
+```
+
+This adds to your `opencode.json`:
+```json
+{
+  "skillsRegistry": {
+    "default": "my-org/my-skills-repo"
+  }
+}
+```
+
+**User-level** (personal default across all projects):
+```bash
+context-harness config set skills-repo my-fork/context-harness-skills --user
+```
+
+This creates/updates `~/.context-harness/config.json`:
+```json
+{
+  "skillsRegistry": {
+    "default": "my-fork/context-harness-skills"
+  }
+}
+```
+
+**Environment variable** (CI/CD or temporary override):
+```bash
+export CONTEXT_HARNESS_SKILLS_REPO=my-org/private-skills
+context-harness skill list  # Uses my-org/private-skills
+```
+
+### Creating a Custom Skills Repository
+
+To create your own skills repository:
+
+1. Fork or create a new repo with this structure:
+   ```
+   my-skills-repo/
+   ├── skills.json          # Registry of available skills
+   └── skill/               # Directory containing skills
+       ├── my-skill/
+       │   └── SKILL.md     # Skill definition with YAML frontmatter
+       └── another-skill/
+           └── SKILL.md
+   ```
+
+2. Create `skills.json`:
+   ```json
+   {
+     "schema_version": "1.0",
+     "skills": [
+       {
+         "name": "my-skill",
+         "description": "What this skill does",
+         "version": "0.1.0",
+         "author": "your-username",
+         "tags": ["category"],
+         "path": "skill/my-skill"
+       }
+     ]
+   }
+   ```
+
+3. Each skill needs a `SKILL.md` with frontmatter:
+   ```markdown
+   ---
+   name: my-skill
+   description: What this skill does
+   version: 0.1.0
+   ---
+   
+   # My Skill
+   
+   Instructions for the AI agent...
+   ```
+
+4. Configure your repo:
+   ```bash
+   context-harness config set skills-repo my-org/my-skills-repo
+   ```
+
+The official repository [`co-labs-co/context-harness-skills`](https://github.com/co-labs-co/context-harness-skills) serves as a reference implementation.
+
 ---
 
 ## How It Works

--- a/src/context_harness/primitives/__init__.py
+++ b/src/context_harness/primitives/__init__.py
@@ -49,8 +49,12 @@ from context_harness.primitives.mcp import (
 from context_harness.primitives.config import (
     AgentConfig,
     CommandConfig,
+    DEFAULT_SKILLS_REPO,
     OpenCodeConfig,
     ProjectConfig,
+    SKILLS_REPO_ENV_VAR,
+    SkillsRegistryConfig,
+    UserConfig,
 )
 from context_harness.primitives.message import (
     Conversation,
@@ -102,8 +106,12 @@ __all__ = [
     # Config types
     "AgentConfig",
     "CommandConfig",
+    "DEFAULT_SKILLS_REPO",
     "OpenCodeConfig",
     "ProjectConfig",
+    "SKILLS_REPO_ENV_VAR",
+    "SkillsRegistryConfig",
+    "UserConfig",
     # Message types
     "Conversation",
     "Message",

--- a/src/context_harness/services/skill_service.py
+++ b/src/context_harness/services/skill_service.py
@@ -17,6 +17,7 @@ from typing import List, Optional, Protocol
 import yaml
 
 from context_harness.primitives import (
+    DEFAULT_SKILLS_REPO,
     ErrorCode,
     Failure,
     Result,
@@ -27,8 +28,6 @@ from context_harness.primitives import (
 )
 
 
-# Central skills repository
-SKILLS_REPO = "co-labs-co/context-harness-skills"
 SKILLS_REGISTRY_PATH = "skills.json"
 SKILLS_DIR = "skill"
 
@@ -181,7 +180,7 @@ class SkillService:
     def __init__(
         self,
         github_client: Optional[GitHubClient] = None,
-        skills_repo: str = SKILLS_REPO,
+        skills_repo: str = DEFAULT_SKILLS_REPO,
     ):
         """Initialize the skill service.
 

--- a/src/context_harness/services/skills_registry.py
+++ b/src/context_harness/services/skills_registry.py
@@ -1,0 +1,177 @@
+"""Skills registry resolution for ContextHarness.
+
+Provides functions to resolve the skills repository with layered precedence:
+1. Environment variable (highest priority)
+2. Project config (opencode.json)
+3. User config (~/.context-harness/config.json)
+4. Default (lowest priority)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Optional, Tuple
+
+from context_harness.primitives import (
+    DEFAULT_SKILLS_REPO,
+    OpenCodeConfig,
+    Result,
+    SKILLS_REPO_ENV_VAR,
+    Success,
+    UserConfig,
+)
+
+
+def resolve_skills_repo(
+    project_config: Optional[OpenCodeConfig] = None,
+    user_config: Optional[UserConfig] = None,
+) -> Tuple[str, str]:
+    """Resolve the skills repository with layered precedence.
+
+    Priority (highest to lowest):
+    1. CONTEXT_HARNESS_SKILLS_REPO environment variable
+    2. Project config (opencode.json skillsRegistry.default)
+    3. User config (~/.context-harness/config.json skillsRegistry.default)
+    4. Default (co-labs-co/context-harness-skills)
+
+    Args:
+        project_config: Optional project configuration (opencode.json)
+        user_config: Optional user configuration
+
+    Returns:
+        Tuple of (repo, source) where source indicates where it came from:
+        - "environment" if from env var
+        - "project" if from opencode.json
+        - "user" if from user config
+        - "default" if using hardcoded default
+    """
+    # 1. Environment variable (highest priority)
+    env_repo = os.environ.get(SKILLS_REPO_ENV_VAR)
+    if env_repo:
+        return (env_repo, "environment")
+
+    # 2. Project config
+    if project_config and project_config.skills_registry:
+        return (project_config.skills_registry.default, "project")
+
+    # 3. User config
+    if user_config and user_config.skills_registry:
+        return (user_config.skills_registry.default, "user")
+
+    # 4. Default
+    return (DEFAULT_SKILLS_REPO, "default")
+
+
+def resolve_skills_repo_with_loading(
+    project_path: Optional[Path] = None,
+) -> Tuple[str, str]:
+    """Resolve skills repo, loading configs as needed.
+
+    This is a convenience function that loads project and user configs
+    automatically. Use resolve_skills_repo() directly if you already
+    have the configs loaded.
+
+    Args:
+        project_path: Optional project path for loading opencode.json
+
+    Returns:
+        Tuple of (repo, source) - see resolve_skills_repo() for details
+    """
+    # 1. Check environment variable first (no loading needed)
+    env_repo = os.environ.get(SKILLS_REPO_ENV_VAR)
+    if env_repo:
+        return (env_repo, "environment")
+
+    # 2. Try to load project config
+    project_config: Optional[OpenCodeConfig] = None
+    if project_path:
+        config_file = project_path / "opencode.json"
+    else:
+        config_file = Path.cwd() / "opencode.json"
+
+    if config_file.exists():
+        try:
+            with open(config_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            project_config = OpenCodeConfig.from_dict(data)
+        except (json.JSONDecodeError, ValueError, OSError):
+            pass  # Invalid or unreadable config, fall through to next option
+
+    if project_config and project_config.skills_registry:
+        return (project_config.skills_registry.default, "project")
+
+    # 3. Try to load user config
+    user_config: Optional[UserConfig] = None
+    user_config_path = UserConfig.config_path()
+
+    if user_config_path.exists():
+        try:
+            with open(user_config_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            user_config = UserConfig.from_dict(data)
+        except (json.JSONDecodeError, ValueError, OSError):
+            pass  # Invalid or unreadable config, fall through to default
+
+    if user_config and user_config.skills_registry:
+        return (user_config.skills_registry.default, "user")
+
+    # 4. Default
+    return (DEFAULT_SKILLS_REPO, "default")
+
+
+def get_skills_repo_info() -> Result[dict]:
+    """Get detailed information about skills repo resolution.
+
+    Returns:
+        Result containing dict with:
+        - repo: The resolved repository
+        - source: Where it came from
+        - env_var: The environment variable name
+        - env_value: Current env var value (if set)
+        - project_value: Value from project config (if set)
+        - user_value: Value from user config (if set)
+        - default_value: The default repository
+    """
+    env_value = os.environ.get(SKILLS_REPO_ENV_VAR)
+
+    # Load project config
+    project_value: Optional[str] = None
+    config_file = Path.cwd() / "opencode.json"
+    if config_file.exists():
+        try:
+            with open(config_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            project_config = OpenCodeConfig.from_dict(data)
+            if project_config.skills_registry:
+                project_value = project_config.skills_registry.default
+        except (json.JSONDecodeError, OSError):
+            pass  # Invalid or unreadable config, project_value stays None
+
+    # Load user config
+    user_value: Optional[str] = None
+    user_config_path = UserConfig.config_path()
+    if user_config_path.exists():
+        try:
+            with open(user_config_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            user_config = UserConfig.from_dict(data)
+            if user_config.skills_registry:
+                user_value = user_config.skills_registry.default
+        except (json.JSONDecodeError, OSError):
+            pass  # Invalid or unreadable config, user_value stays None
+
+    repo, source = resolve_skills_repo_with_loading()
+
+    return Success(
+        value={
+            "repo": repo,
+            "source": source,
+            "env_var": SKILLS_REPO_ENV_VAR,
+            "env_value": env_value,
+            "project_value": project_value,
+            "user_value": user_value,
+            "default_value": DEFAULT_SKILLS_REPO,
+        }
+    )

--- a/src/context_harness/services/user_config_service.py
+++ b/src/context_harness/services/user_config_service.py
@@ -1,0 +1,151 @@
+"""User configuration service for ContextHarness.
+
+Handles reading/writing user-level configuration (~/.context-harness/config.json).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from context_harness.primitives import (
+    ErrorCode,
+    Failure,
+    Result,
+    Success,
+    UserConfig,
+)
+
+
+class UserConfigService:
+    """Service for managing user-level configuration.
+
+    This service handles:
+    - Loading and parsing ~/.context-harness/config.json
+    - Saving user configuration changes
+    - Creating the config directory if needed
+
+    Example:
+        service = UserConfigService()
+        result = service.load()
+        if isinstance(result, Success):
+            config = result.value
+            print(config.skills_registry)
+    """
+
+    def __init__(self, config_path: Optional[Path] = None):
+        """Initialize the user config service.
+
+        Args:
+            config_path: Override config file path (for testing)
+        """
+        self._config_path = config_path or UserConfig.config_path()
+
+    @property
+    def config_path(self) -> Path:
+        """Get the config file path."""
+        return self._config_path
+
+    @property
+    def config_dir(self) -> Path:
+        """Get the config directory path."""
+        return self._config_path.parent
+
+    def load(self) -> Result[UserConfig]:
+        """Load user configuration.
+
+        Returns:
+            Result containing UserConfig or Failure
+        """
+        if not self._config_path.exists():
+            # Return empty config if file doesn't exist (not an error)
+            return Success(value=UserConfig())
+
+        try:
+            with open(self._config_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            config = UserConfig.from_dict(data)
+            return Success(value=config)
+        except json.JSONDecodeError as e:
+            return Failure(
+                error=f"Invalid JSON in user config: {e}",
+                code=ErrorCode.CONFIG_INVALID,
+                details={"path": str(self._config_path), "error": str(e)},
+            )
+        except PermissionError:
+            return Failure(
+                error=f"Permission denied reading: {self._config_path}",
+                code=ErrorCode.PERMISSION_DENIED,
+                details={"path": str(self._config_path)},
+            )
+        except Exception as e:
+            return Failure(
+                error=f"Error loading user config: {e}",
+                code=ErrorCode.UNKNOWN,
+                details={"path": str(self._config_path), "error": str(e)},
+            )
+
+    def save(self, config: UserConfig) -> Result[Path]:
+        """Save user configuration.
+
+        Args:
+            config: Configuration to save
+
+        Returns:
+            Result containing the saved file path or Failure
+        """
+        try:
+            # Ensure config directory exists
+            self.config_dir.mkdir(parents=True, exist_ok=True)
+
+            data = config.to_dict()
+
+            with open(self._config_path, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
+                f.write("\n")  # Trailing newline
+
+            return Success(value=self._config_path)
+
+        except PermissionError:
+            return Failure(
+                error=f"Permission denied writing to: {self._config_path}",
+                code=ErrorCode.PERMISSION_DENIED,
+                details={"path": str(self._config_path)},
+            )
+        except Exception as e:
+            return Failure(
+                error=f"Error saving user config: {e}",
+                code=ErrorCode.UNKNOWN,
+                details={"path": str(self._config_path), "error": str(e)},
+            )
+
+    def exists(self) -> bool:
+        """Check if user config file exists.
+
+        Returns:
+            True if config file exists
+        """
+        return self._config_path.exists()
+
+    def ensure_config_dir(self) -> Result[Path]:
+        """Ensure the config directory exists.
+
+        Returns:
+            Result containing the directory path or Failure
+        """
+        try:
+            self.config_dir.mkdir(parents=True, exist_ok=True)
+            return Success(value=self.config_dir)
+        except PermissionError:
+            return Failure(
+                error=f"Permission denied creating: {self.config_dir}",
+                code=ErrorCode.PERMISSION_DENIED,
+                details={"path": str(self.config_dir)},
+            )
+        except Exception as e:
+            return Failure(
+                error=f"Error creating config directory: {e}",
+                code=ErrorCode.UNKNOWN,
+                details={"path": str(self.config_dir), "error": str(e)},
+            )

--- a/tests/unit/services/test_skills_registry.py
+++ b/tests/unit/services/test_skills_registry.py
@@ -1,0 +1,331 @@
+"""Unit tests for skills registry resolution."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Generator
+from unittest.mock import patch
+
+import pytest
+
+from context_harness.primitives import (
+    DEFAULT_SKILLS_REPO,
+    OpenCodeConfig,
+    SKILLS_REPO_ENV_VAR,
+    SkillsRegistryConfig,
+    Success,
+    UserConfig,
+)
+from context_harness.services.skills_registry import (
+    get_skills_repo_info,
+    resolve_skills_repo,
+    resolve_skills_repo_with_loading,
+)
+
+
+class TestSkillsRegistryConfig:
+    """Tests for SkillsRegistryConfig primitive."""
+
+    def test_default_values(self) -> None:
+        """Test default values."""
+        config = SkillsRegistryConfig()
+        assert config.default == DEFAULT_SKILLS_REPO
+
+    def test_custom_repo(self) -> None:
+        """Test with custom repo."""
+        config = SkillsRegistryConfig(default="my-org/my-skills")
+        assert config.default == "my-org/my-skills"
+
+    def test_from_dict(self) -> None:
+        """Test creating from dictionary."""
+        config = SkillsRegistryConfig.from_dict({"default": "custom/repo"})
+        assert config.default == "custom/repo"
+
+    def test_from_dict_empty(self) -> None:
+        """Test creating from empty dictionary uses defaults."""
+        config = SkillsRegistryConfig.from_dict({})
+        assert config.default == DEFAULT_SKILLS_REPO
+
+    def test_to_dict_default(self) -> None:
+        """Test to_dict with default value returns empty dict."""
+        config = SkillsRegistryConfig()
+        assert config.to_dict() == {}
+
+    def test_to_dict_custom(self) -> None:
+        """Test to_dict with custom value."""
+        config = SkillsRegistryConfig(default="custom/repo")
+        assert config.to_dict() == {"default": "custom/repo"}
+
+
+class TestUserConfig:
+    """Tests for UserConfig primitive."""
+
+    def test_default_values(self) -> None:
+        """Test default values."""
+        config = UserConfig()
+        assert config.skills_registry is None
+
+    def test_with_skills_registry(self) -> None:
+        """Test with skills registry."""
+        registry = SkillsRegistryConfig(default="my-org/skills")
+        config = UserConfig(skills_registry=registry)
+        assert config.skills_registry is not None
+        assert config.skills_registry.default == "my-org/skills"
+
+    def test_from_dict(self) -> None:
+        """Test creating from dictionary."""
+        config = UserConfig.from_dict({"skillsRegistry": {"default": "custom/repo"}})
+        assert config.skills_registry is not None
+        assert config.skills_registry.default == "custom/repo"
+
+    def test_from_dict_empty(self) -> None:
+        """Test creating from empty dictionary."""
+        config = UserConfig.from_dict({})
+        assert config.skills_registry is None
+
+    def test_to_dict_empty(self) -> None:
+        """Test to_dict with no values returns empty dict."""
+        config = UserConfig()
+        assert config.to_dict() == {}
+
+    def test_to_dict_with_registry(self) -> None:
+        """Test to_dict with skills registry."""
+        config = UserConfig(skills_registry=SkillsRegistryConfig(default="custom/repo"))
+        assert config.to_dict() == {"skillsRegistry": {"default": "custom/repo"}}
+
+    def test_config_path(self) -> None:
+        """Test config path is in home directory."""
+        path = UserConfig.config_path()
+        assert path == Path.home() / ".context-harness" / "config.json"
+
+    def test_config_dir(self) -> None:
+        """Test config directory path."""
+        dir_path = UserConfig.config_dir()
+        assert dir_path == Path.home() / ".context-harness"
+
+
+class TestOpenCodeConfigSkillsRegistry:
+    """Tests for skills_registry in OpenCodeConfig."""
+
+    def test_default_no_registry(self) -> None:
+        """Test default config has no skills registry."""
+        config = OpenCodeConfig()
+        assert config.skills_registry is None
+
+    def test_with_skills_registry(self) -> None:
+        """Test config with skills registry."""
+        registry = SkillsRegistryConfig(default="my-org/skills")
+        config = OpenCodeConfig(skills_registry=registry)
+        assert config.skills_registry is not None
+        assert config.skills_registry.default == "my-org/skills"
+
+    def test_from_dict_with_registry(self) -> None:
+        """Test parsing skills registry from dict."""
+        config = OpenCodeConfig.from_dict(
+            {"skillsRegistry": {"default": "custom/repo"}}
+        )
+        assert config.skills_registry is not None
+        assert config.skills_registry.default == "custom/repo"
+
+    def test_from_dict_without_registry(self) -> None:
+        """Test parsing without skills registry."""
+        config = OpenCodeConfig.from_dict({})
+        assert config.skills_registry is None
+
+    def test_to_dict_with_registry(self) -> None:
+        """Test serializing skills registry."""
+        config = OpenCodeConfig(
+            skills_registry=SkillsRegistryConfig(default="custom/repo")
+        )
+        result = config.to_dict()
+        assert "skillsRegistry" in result
+        assert result["skillsRegistry"] == {"default": "custom/repo"}
+
+    def test_to_dict_without_registry(self) -> None:
+        """Test serializing without skills registry."""
+        config = OpenCodeConfig()
+        result = config.to_dict()
+        assert "skillsRegistry" not in result
+
+
+class TestResolveSkillsRepo:
+    """Tests for resolve_skills_repo function."""
+
+    def test_default_no_config(self) -> None:
+        """Test returns default when no config provided."""
+        repo, source = resolve_skills_repo()
+        assert repo == DEFAULT_SKILLS_REPO
+        assert source == "default"
+
+    def test_env_var_highest_priority(self) -> None:
+        """Test environment variable has highest priority."""
+        with patch.dict(os.environ, {SKILLS_REPO_ENV_VAR: "env/repo"}):
+            project_config = OpenCodeConfig(
+                skills_registry=SkillsRegistryConfig(default="project/repo")
+            )
+            user_config = UserConfig(
+                skills_registry=SkillsRegistryConfig(default="user/repo")
+            )
+            repo, source = resolve_skills_repo(project_config, user_config)
+            assert repo == "env/repo"
+            assert source == "environment"
+
+    def test_project_config_over_user(self) -> None:
+        """Test project config takes precedence over user config."""
+        project_config = OpenCodeConfig(
+            skills_registry=SkillsRegistryConfig(default="project/repo")
+        )
+        user_config = UserConfig(
+            skills_registry=SkillsRegistryConfig(default="user/repo")
+        )
+        repo, source = resolve_skills_repo(project_config, user_config)
+        assert repo == "project/repo"
+        assert source == "project"
+
+    def test_user_config_over_default(self) -> None:
+        """Test user config takes precedence over default."""
+        user_config = UserConfig(
+            skills_registry=SkillsRegistryConfig(default="user/repo")
+        )
+        repo, source = resolve_skills_repo(user_config=user_config)
+        assert repo == "user/repo"
+        assert source == "user"
+
+    def test_project_config_without_registry(self) -> None:
+        """Test project config without registry falls through."""
+        project_config = OpenCodeConfig()  # No skills_registry
+        user_config = UserConfig(
+            skills_registry=SkillsRegistryConfig(default="user/repo")
+        )
+        repo, source = resolve_skills_repo(project_config, user_config)
+        assert repo == "user/repo"
+        assert source == "user"
+
+
+class TestResolveSkillsRepoWithLoading:
+    """Tests for resolve_skills_repo_with_loading function."""
+
+    @pytest.fixture
+    def clean_env(self) -> Generator[None, None, None]:
+        """Ensure env var is not set."""
+        original = os.environ.pop(SKILLS_REPO_ENV_VAR, None)
+        yield
+        if original is not None:
+            os.environ[SKILLS_REPO_ENV_VAR] = original
+
+    def test_env_var_override(self, clean_env: None) -> None:
+        """Test environment variable override."""
+        with patch.dict(os.environ, {SKILLS_REPO_ENV_VAR: "env/override"}):
+            repo, source = resolve_skills_repo_with_loading()
+            assert repo == "env/override"
+            assert source == "environment"
+
+    def test_default_when_no_config(self, clean_env: None, tmp_path: Path) -> None:
+        """Test returns default when no config files exist."""
+        with patch(
+            "context_harness.services.skills_registry.Path.cwd", return_value=tmp_path
+        ):
+            with patch.object(
+                UserConfig, "config_path", return_value=tmp_path / "nonexistent.json"
+            ):
+                repo, source = resolve_skills_repo_with_loading()
+                assert repo == DEFAULT_SKILLS_REPO
+                assert source == "default"
+
+    def test_loads_project_config(self, clean_env: None, tmp_path: Path) -> None:
+        """Test loads project config from opencode.json."""
+        # Create opencode.json with skills registry
+        config_file = tmp_path / "opencode.json"
+        config_file.write_text(
+            json.dumps({"skillsRegistry": {"default": "project/loaded"}})
+        )
+
+        with patch(
+            "context_harness.services.skills_registry.Path.cwd", return_value=tmp_path
+        ):
+            with patch.object(
+                UserConfig, "config_path", return_value=tmp_path / "nonexistent.json"
+            ):
+                repo, source = resolve_skills_repo_with_loading(tmp_path)
+                assert repo == "project/loaded"
+                assert source == "project"
+
+    def test_loads_user_config(self, clean_env: None, tmp_path: Path) -> None:
+        """Test loads user config when project config missing."""
+        # Create user config
+        user_config_path = tmp_path / "user_config.json"
+        user_config_path.write_text(
+            json.dumps({"skillsRegistry": {"default": "user/loaded"}})
+        )
+
+        with patch(
+            "context_harness.services.skills_registry.Path.cwd", return_value=tmp_path
+        ):
+            with patch.object(UserConfig, "config_path", return_value=user_config_path):
+                repo, source = resolve_skills_repo_with_loading()
+                assert repo == "user/loaded"
+                assert source == "user"
+
+
+class TestGetSkillsRepoInfo:
+    """Tests for get_skills_repo_info function."""
+
+    @pytest.fixture
+    def clean_env(self) -> Generator[None, None, None]:
+        """Ensure env var is not set."""
+        original = os.environ.pop(SKILLS_REPO_ENV_VAR, None)
+        yield
+        if original is not None:
+            os.environ[SKILLS_REPO_ENV_VAR] = original
+
+    def test_returns_success(self, clean_env: None, tmp_path: Path) -> None:
+        """Test returns success result."""
+        with patch(
+            "context_harness.services.skills_registry.Path.cwd", return_value=tmp_path
+        ):
+            with patch.object(
+                UserConfig, "config_path", return_value=tmp_path / "nonexistent.json"
+            ):
+                result = get_skills_repo_info()
+                assert isinstance(result, Success)
+                info = result.value
+                assert "repo" in info
+                assert "source" in info
+                assert "env_var" in info
+                assert info["env_var"] == SKILLS_REPO_ENV_VAR
+
+    def test_includes_all_values(self, clean_env: None, tmp_path: Path) -> None:
+        """Test includes all configuration values."""
+        # Set env var
+        with patch.dict(os.environ, {SKILLS_REPO_ENV_VAR: "env/repo"}):
+            # Create project config
+            config_file = tmp_path / "opencode.json"
+            config_file.write_text(
+                json.dumps({"skillsRegistry": {"default": "project/repo"}})
+            )
+
+            # Create user config
+            user_config_path = tmp_path / "user_config.json"
+            user_config_path.write_text(
+                json.dumps({"skillsRegistry": {"default": "user/repo"}})
+            )
+
+            with patch(
+                "context_harness.services.skills_registry.Path.cwd",
+                return_value=tmp_path,
+            ):
+                with patch.object(
+                    UserConfig, "config_path", return_value=user_config_path
+                ):
+                    result = get_skills_repo_info()
+                    assert isinstance(result, Success)
+                    info = result.value
+
+                    assert info["repo"] == "env/repo"
+                    assert info["source"] == "environment"
+                    assert info["env_value"] == "env/repo"
+                    assert info["project_value"] == "project/repo"
+                    assert info["user_value"] == "user/repo"
+                    assert info["default_value"] == DEFAULT_SKILLS_REPO

--- a/tests/unit/services/test_user_config_service.py
+++ b/tests/unit/services/test_user_config_service.py
@@ -1,0 +1,151 @@
+"""Unit tests for UserConfigService."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from context_harness.primitives import (
+    Failure,
+    SkillsRegistryConfig,
+    Success,
+    UserConfig,
+)
+from context_harness.services.user_config_service import UserConfigService
+
+
+class TestUserConfigService:
+    """Tests for UserConfigService."""
+
+    def test_load_nonexistent_returns_empty(self, tmp_path: Path) -> None:
+        """Test loading nonexistent config returns empty UserConfig."""
+        config_path = tmp_path / "config.json"
+        service = UserConfigService(config_path=config_path)
+
+        result = service.load()
+
+        assert isinstance(result, Success)
+        assert result.value.skills_registry is None
+
+    def test_load_valid_config(self, tmp_path: Path) -> None:
+        """Test loading valid config file."""
+        config_path = tmp_path / "config.json"
+        config_path.write_text(
+            json.dumps({"skillsRegistry": {"default": "my-org/skills"}})
+        )
+        service = UserConfigService(config_path=config_path)
+
+        result = service.load()
+
+        assert isinstance(result, Success)
+        assert result.value.skills_registry is not None
+        assert result.value.skills_registry.default == "my-org/skills"
+
+    def test_load_invalid_json(self, tmp_path: Path) -> None:
+        """Test loading invalid JSON returns failure."""
+        config_path = tmp_path / "config.json"
+        config_path.write_text("not valid json {{{")
+        service = UserConfigService(config_path=config_path)
+
+        result = service.load()
+
+        assert isinstance(result, Failure)
+        assert "Invalid JSON" in result.error
+
+    def test_save_creates_directory(self, tmp_path: Path) -> None:
+        """Test save creates config directory if missing."""
+        config_path = tmp_path / "subdir" / "config.json"
+        service = UserConfigService(config_path=config_path)
+        config = UserConfig(
+            skills_registry=SkillsRegistryConfig(default="my-org/skills")
+        )
+
+        result = service.save(config)
+
+        assert isinstance(result, Success)
+        assert config_path.exists()
+        assert config_path.parent.exists()
+
+    def test_save_and_load_roundtrip(self, tmp_path: Path) -> None:
+        """Test saving and loading preserves data."""
+        config_path = tmp_path / "config.json"
+        service = UserConfigService(config_path=config_path)
+        original = UserConfig(
+            skills_registry=SkillsRegistryConfig(default="my-org/skills")
+        )
+
+        service.save(original)
+        result = service.load()
+
+        assert isinstance(result, Success)
+        assert result.value.skills_registry is not None
+        assert result.value.skills_registry.default == "my-org/skills"
+
+    def test_exists_false_when_missing(self, tmp_path: Path) -> None:
+        """Test exists returns false when file missing."""
+        config_path = tmp_path / "config.json"
+        service = UserConfigService(config_path=config_path)
+
+        assert service.exists() is False
+
+    def test_exists_true_when_present(self, tmp_path: Path) -> None:
+        """Test exists returns true when file present."""
+        config_path = tmp_path / "config.json"
+        config_path.write_text("{}")
+        service = UserConfigService(config_path=config_path)
+
+        assert service.exists() is True
+
+    def test_config_path_property(self, tmp_path: Path) -> None:
+        """Test config_path property."""
+        config_path = tmp_path / "config.json"
+        service = UserConfigService(config_path=config_path)
+
+        assert service.config_path == config_path
+
+    def test_config_dir_property(self, tmp_path: Path) -> None:
+        """Test config_dir property."""
+        config_path = tmp_path / "subdir" / "config.json"
+        service = UserConfigService(config_path=config_path)
+
+        assert service.config_dir == tmp_path / "subdir"
+
+    def test_ensure_config_dir_creates_directory(self, tmp_path: Path) -> None:
+        """Test ensure_config_dir creates directory."""
+        config_path = tmp_path / "new_dir" / "config.json"
+        service = UserConfigService(config_path=config_path)
+
+        result = service.ensure_config_dir()
+
+        assert isinstance(result, Success)
+        assert (tmp_path / "new_dir").exists()
+
+    def test_ensure_config_dir_idempotent(self, tmp_path: Path) -> None:
+        """Test ensure_config_dir is idempotent."""
+        config_path = tmp_path / "existing_dir" / "config.json"
+        (tmp_path / "existing_dir").mkdir()
+        service = UserConfigService(config_path=config_path)
+
+        result = service.ensure_config_dir()
+
+        assert isinstance(result, Success)
+        assert (tmp_path / "existing_dir").exists()
+
+    def test_save_empty_config(self, tmp_path: Path) -> None:
+        """Test saving empty config creates minimal file."""
+        config_path = tmp_path / "config.json"
+        service = UserConfigService(config_path=config_path)
+        config = UserConfig()
+
+        result = service.save(config)
+
+        assert isinstance(result, Success)
+        # Empty config should produce {}
+        content = json.loads(config_path.read_text())
+        assert content == {}
+
+    def test_default_config_path(self) -> None:
+        """Test default config path is user home."""
+        service = UserConfigService()
+        expected = Path.home() / ".context-harness" / "config.json"
+        assert service.config_path == expected


### PR DESCRIPTION
## Summary

Implement user-configurable default skills registry repository (Issue #63).

- Add layered configuration with environment variable, project config, and user config precedence
- Add `context-harness config` CLI commands for configuration management
- Support both `owner/repo` and full GitHub URL formats (automatically normalized)
- Add 44 new unit tests for configuration services

## Changes

### Environment Variable Support
- Added `CONTEXT_HARNESS_SKILLS_REPO` environment variable (highest priority)

### Project-Level Config (opencode.json)
- Added `skillsRegistry.default` field to OpenCodeConfig
- Skills repository can be configured per-project

### User-Level Config (~/.context-harness/config.json)
- Added new user configuration file for global settings
- Added `UserConfig` primitive and `UserConfigService`

### CLI Commands
| Command | Description |
|---------|-------------|
| `context-harness config list` | Show all configuration values and sources |
| `context-harness config get skills-repo` | Get current value with source info |
| `context-harness config set skills-repo <repo>` | Set in project config (default) |
| `context-harness config set skills-repo <repo> --user` | Set in user config |
| `context-harness config unset skills-repo` | Remove from project config |
| `context-harness config unset skills-repo --user` | Remove from user config |

### Repository Format Support

Both formats are accepted and automatically normalized to `owner/repo`:

```bash
# Short format (stored as-is)
context-harness config set skills-repo my-org/my-skills

# Full GitHub URL (normalized to owner/repo)
context-harness config set skills-repo https://github.com/my-org/my-skills

# URL with .git suffix (also normalized)
context-harness config set skills-repo https://github.com/my-org/my-skills.git
```

All of the above store `my-org/my-skills` in the configuration.

### Configuration Precedence (highest to lowest)

| Priority | Source | Location | Use Case |
|----------|--------|----------|----------|
| 1 | Environment Variable | `CONTEXT_HARNESS_SKILLS_REPO` | CI/CD, temporary overrides |
| 2 | Project Config | `opencode.json` → `skillsRegistry.default` | Per-project custom repo |
| 3 | User Config | `~/.context-harness/config.json` | Personal default |
| 4 | Default | Hardcoded | Official skills repository |

## Files Changed

### New Files
- `src/context_harness/services/skills_registry.py` - Resolution logic with layered precedence
- `src/context_harness/services/user_config_service.py` - User config management
- `tests/unit/services/test_skills_registry.py` - 31 tests for resolution logic
- `tests/unit/services/test_user_config_service.py` - 13 tests for user config service

### Modified Files
- `src/context_harness/cli.py` - Added `config` command group with get/set/list/unset
- `src/context_harness/primitives/config.py` - Added `SkillsRegistryConfig`, `UserConfig`
- `src/context_harness/primitives/__init__.py` - Exported new primitives
- `src/context_harness/skills.py` - Updated to use configurable repo
- `src/context_harness/services/skill_service.py` - Updated default constant
- `README.md` - Added custom skills repository documentation

## Testing

```bash
# 207 unit tests pass
uv run pytest tests/unit/ -v

# Manual testing examples
context-harness config list
context-harness config get skills-repo

# Set using short format
context-harness config set skills-repo my-org/my-skills --user

# Set using full GitHub URL
context-harness config set skills-repo https://github.com/my-org/my-skills --user

# Verify it was normalized
context-harness config get skills-repo
# Output: skills-repo: my-org/my-skills

# Clean up
context-harness config unset skills-repo --user
```

## Documentation

README.md updated with:
- Configuration precedence table
- Both `owner/repo` and full URL format examples
- CLI usage examples for all commands
- How to create a custom skills repository

Closes #63