### PR TITLE
feat(cli): add skills.json regeneration to upgrade-repo and comprehensive tests

### DIFF
--- a/src/context_harness/services/skill_service.py
+++ b/src/context_harness/services/skill_service.py
@@ -1035,6 +1035,11 @@ class SkillService:
         self._write_scaffold_registry_version(repo_path)
         self._update_json_version_markers(repo_path)
 
+        # Regenerate skills.json with full metadata from skill/ directories
+        # This ensures the web frontend has name, description, version, tags
+        # instead of stale id-only entries from the old schema
+        self._regenerate_skills_json(repo_path)
+
         return Success(
             value={
                 "current_version": current_version,
@@ -1205,7 +1210,9 @@ class SkillService:
             # Extract owner/repo from URL
             if "github.com" in url:
                 # Handle both https and ssh URLs
-                parts = url.replace(".git", "").replace("git@github.com:", "").split("/")
+                parts = (
+                    url.replace(".git", "").replace("git@github.com:", "").split("/")
+                )
                 if len(parts) >= 2:
                     return f"{parts[-2]}/{parts[-1]}"
         except (subprocess.CalledProcessError, IndexError):
@@ -1237,10 +1244,16 @@ class SkillService:
             "scripts/validate-skills.py": self._write_scaffold_validate_skills_script,
             # HTTP registry (Docker/nginx)
             "Dockerfile": self._write_scaffold_dockerfile,
-            "docker-compose.yml": lambda p: self._write_scaffold_docker_compose(p, repo_name),
+            "docker-compose.yml": lambda p: self._write_scaffold_docker_compose(
+                p, repo_name
+            ),
             "registry/nginx.conf": self._write_scaffold_nginx_conf,
-            "registry/web/index.html": lambda p: self._write_scaffold_index_html(p, repo_name),
-            "registry/web/skill.html": lambda p: self._write_scaffold_skill_html(p, repo_name),
+            "registry/web/index.html": lambda p: self._write_scaffold_index_html(
+                p, repo_name
+            ),
+            "registry/web/skill.html": lambda p: self._write_scaffold_skill_html(
+                p, repo_name
+            ),
             # AI agent instructions
             "llms.txt": self._write_scaffold_llms_txt,
             # Release configuration
@@ -1249,10 +1262,14 @@ class SkillService:
             # Git configuration
             ".gitignore": self._write_scaffold_gitignore,
             # Marketplace manifest (requires repo_name)
-            "marketplace.json": lambda p: self._write_scaffold_marketplace_json(p, repo_name),
+            "marketplace.json": lambda p: self._write_scaffold_marketplace_json(
+                p, repo_name
+            ),
             # Documentation (requires repo_name)
             "README.md": lambda p: self._write_scaffold_readme(p, repo_name),
-            "CONTRIBUTING.md": lambda p: self._write_scaffold_contributing(p, repo_name),
+            "CONTRIBUTING.md": lambda p: self._write_scaffold_contributing(
+                p, repo_name
+            ),
             "QUICKSTART.md": lambda p: self._write_scaffold_quickstart(p, repo_name),
         }
 
@@ -1289,6 +1306,79 @@ class SkillService:
                 )
             except (json.JSONDecodeError, KeyError):
                 pass
+
+    def _regenerate_skills_json(self, repo_path: Path) -> None:
+        """Regenerate skills.json by scanning skill/ directories for metadata.
+
+        Parses SKILL.md frontmatter and version.txt for each skill directory,
+        producing the full skills.json that the web frontend requires.
+
+        This is the Python equivalent of what scripts/sync-registry.py does,
+        but runs inline during upgrade-repo so skills.json is never stale.
+
+        Args:
+            repo_path: Path to the registry repository
+        """
+        import hashlib
+
+        skills_dir = repo_path / "skill"
+        if not skills_dir.exists():
+            return
+
+        skills_json_path = repo_path / "skills.json"
+
+        # Collect skill metadata from each skill directory
+        skills = []
+        for skill_dir in sorted(skills_dir.iterdir()):
+            if not skill_dir.is_dir():
+                continue
+
+            skill_md = skill_dir / "SKILL.md"
+            if not skill_md.exists():
+                continue
+
+            # Parse frontmatter using existing method
+            try:
+                metadata = self._parse_skill_frontmatter(skill_dir)
+            except Exception:
+                # If parsing fails, use directory name as fallback
+                metadata = SkillMetadata(
+                    name=skill_dir.name,
+                    description="",
+                )
+
+            # Read version from version.txt (fall back to frontmatter or 0.1.0)
+            version = metadata.version or "0.1.0"
+            version_txt = skill_dir / "version.txt"
+            if version_txt.exists():
+                version = version_txt.read_text(encoding="utf-8").strip() or version
+
+            # Compute content hash for change detection
+            content_hash = hashlib.sha256(skill_md.read_bytes()).hexdigest()[:16]
+
+            skill_entry = {
+                "name": metadata.name or skill_dir.name,
+                "description": metadata.description or "",
+                "version": version,
+                "author": metadata.author or "",
+                "tags": metadata.tags or [],
+                "path": f"skill/{skill_dir.name}",
+                "content_hash": content_hash,
+            }
+
+            # Only include min_context_harness_version if present
+            # (future-proofing, parsed from frontmatter if available)
+            skills.append(skill_entry)
+
+        # Write the full skills.json
+        registry = {
+            "schema_version": "1.1",
+            "registry_version": CH_VERSION,
+            "skills": skills,
+        }
+        skills_json_path.write_text(
+            json.dumps(registry, indent=2) + "\n", encoding="utf-8"
+        )
 
     def _write_registry_scaffold(self, repo_path: Path, repo_name: str) -> None:
         """Write the full skills registry scaffold with CI/CD automation.
@@ -3295,9 +3385,7 @@ python scripts/validate_skills.py
 
     # -- HTTP Registry Scaffold Methods --------------------------------------
 
-    def _write_scaffold_marketplace_json(
-        self, repo_path: Path, repo_name: str
-    ) -> None:
+    def _write_scaffold_marketplace_json(self, repo_path: Path, repo_name: str) -> None:
         """Write marketplace.json — standardized manifest for plugin discovery.
 
         This format provides compatibility with future Claude Code plugin
@@ -3341,9 +3429,7 @@ python scripts/validate_skills.py
             json.dumps(marketplace, indent=2) + "\n", encoding="utf-8"
         )
 
-    def _write_scaffold_http_registry(
-        self, repo_path: Path, repo_name: str
-    ) -> None:
+    def _write_scaffold_http_registry(self, repo_path: Path, repo_name: str) -> None:
         """Write HTTP registry hosting files for Docker/nginx deployment.
 
         Creates a complete setup for hosting the skills registry via HTTP:
@@ -3398,9 +3484,7 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \\
 """
         (repo_path / "Dockerfile").write_text(content, encoding="utf-8")
 
-    def _write_scaffold_docker_compose(
-        self, repo_path: Path, repo_name: str
-    ) -> None:
+    def _write_scaffold_docker_compose(self, repo_path: Path, repo_name: str) -> None:
         """Write docker-compose.yml for easy deployment."""
         content = f"""\
 # ContextHarness Skills Registry
@@ -3562,9 +3646,7 @@ See `/skills.json` for the complete list of available skills with descriptions.
 """
         (repo_path / "llms.txt").write_text(content, encoding="utf-8")
 
-    def _write_scaffold_index_html(
-        self, repo_path: Path, repo_name: str
-    ) -> None:
+    def _write_scaffold_index_html(self, repo_path: Path, repo_name: str) -> None:
         """Write index.html - static frontend for browsing skills.
 
         A clean shadcn-inspired UI using Tailwind CSS with the project theme.
@@ -3843,9 +3925,7 @@ tags: [category]
             content, encoding="utf-8"
         )
 
-    def _write_scaffold_skill_html(
-        self, repo_path: Path, repo_name: str
-    ) -> None:
+    def _write_scaffold_skill_html(self, repo_path: Path, repo_name: str) -> None:
         """Write skill.html - individual skill detail page with file explorer."""
         content = """\
 <!DOCTYPE html>

--- a/src/context_harness/services/skill_service.py
+++ b/src/context_harness/services/skill_service.py
@@ -8,6 +8,7 @@ Supports both OpenCode (.opencode/skill/) and Claude Code (.claude/skills/) tool
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 import shutil
@@ -1280,20 +1281,12 @@ class SkillService:
             self._write_scaffold_registry_version(repo_path)
 
     def _update_json_version_markers(self, repo_path: Path) -> None:
-        """Update registry_version in skills.json and marketplace.json."""
-        # Update skills.json
-        skills_json_path = repo_path / "skills.json"
-        if skills_json_path.exists():
-            try:
-                data = json.loads(skills_json_path.read_text(encoding="utf-8"))
-                data["registry_version"] = CH_VERSION
-                data["schema_version"] = "1.1"
-                skills_json_path.write_text(
-                    json.dumps(data, indent=2) + "\n", encoding="utf-8"
-                )
-            except (json.JSONDecodeError, KeyError):
-                pass  # Don't fail if JSON is malformed
+        """Update registry_version in marketplace.json.
 
+        Note: skills.json is handled by _regenerate_skills_json() which
+        rewrites the file from scratch during upgrade-repo, so we skip it
+        here to avoid redundant I/O.
+        """
         # Update marketplace.json
         marketplace_path = repo_path / "marketplace.json"
         if marketplace_path.exists():
@@ -1319,8 +1312,6 @@ class SkillService:
         Args:
             repo_path: Path to the registry repository
         """
-        import hashlib
-
         skills_dir = repo_path / "skill"
         if not skills_dir.exists():
             return
@@ -1356,7 +1347,7 @@ class SkillService:
             # Compute content hash for change detection
             content_hash = hashlib.sha256(skill_md.read_bytes()).hexdigest()[:16]
 
-            skill_entry = {
+            skill_entry: dict = {
                 "name": metadata.name or skill_dir.name,
                 "description": metadata.description or "",
                 "version": version,
@@ -1366,8 +1357,19 @@ class SkillService:
                 "content_hash": content_hash,
             }
 
-            # Only include min_context_harness_version if present
-            # (future-proofing, parsed from frontmatter if available)
+            # Include min_context_harness_version if present in frontmatter
+            # to maintain parity with sync-registry.py CI output
+            try:
+                raw_fm = skill_md.read_text(encoding="utf-8")
+                fm_end = raw_fm.find("---", 3)
+                if fm_end > 0:
+                    fm_data = yaml.safe_load(raw_fm[3:fm_end].strip()) or {}
+                    min_ch = fm_data.get("min_context_harness_version")
+                    if min_ch:
+                        skill_entry["min_context_harness_version"] = str(min_ch)
+            except Exception:
+                pass  # Don't fail on optional field
+
             skills.append(skill_entry)
 
         # Write the full skills.json
@@ -1376,9 +1378,12 @@ class SkillService:
             "registry_version": CH_VERSION,
             "skills": skills,
         }
-        skills_json_path.write_text(
-            json.dumps(registry, indent=2) + "\n", encoding="utf-8"
-        )
+        try:
+            skills_json_path.write_text(
+                json.dumps(registry, indent=2) + "\n", encoding="utf-8"
+            )
+        except OSError:
+            pass  # Don't fail the upgrade if skills.json can't be written
 
     def _write_registry_scaffold(self, repo_path: Path, repo_name: str) -> None:
         """Write the full skills registry scaffold with CI/CD automation.

--- a/src/context_harness/services/skill_service.py
+++ b/src/context_harness/services/skill_service.py
@@ -1039,7 +1039,9 @@ class SkillService:
         # Regenerate skills.json with full metadata from skill/ directories
         # This ensures the web frontend has name, description, version, tags
         # instead of stale id-only entries from the old schema
-        self._regenerate_skills_json(repo_path)
+        if self._regenerate_skills_json(repo_path):
+            if "skills.json" not in updated_files:
+                updated_files.append("skills.json")
 
         return Success(
             value={
@@ -1300,21 +1302,41 @@ class SkillService:
             except (json.JSONDecodeError, KeyError):
                 pass
 
-    def _regenerate_skills_json(self, repo_path: Path) -> None:
+    def _regenerate_skills_json(self, repo_path: Path) -> bool:
         """Regenerate skills.json by scanning skill/ directories for metadata.
 
         Parses SKILL.md frontmatter and version.txt for each skill directory,
-        producing the full skills.json that the web frontend requires.
+        producing the full skills.json that the web frontend requires
+        (name, version, description, tags, author, content_hash).
 
-        This is the Python equivalent of what scripts/sync-registry.py does,
-        but runs inline during upgrade-repo so skills.json is never stale.
+        Unlike scripts/sync-registry.py, this does NOT generate per-skill
+        .listing.json files — only the top-level skills.json.
+
+        If no skill/ directory exists, falls back to updating version markers
+        in any existing skills.json without altering the skills list.
 
         Args:
             repo_path: Path to the registry repository
+
+        Returns:
+            True if skills.json was written, False otherwise.
         """
         skills_dir = repo_path / "skill"
         if not skills_dir.exists():
-            return
+            # No skill/ dir — still update version markers in existing skills.json
+            skills_json_path = repo_path / "skills.json"
+            if skills_json_path.exists():
+                try:
+                    data = json.loads(skills_json_path.read_text(encoding="utf-8"))
+                    data["registry_version"] = CH_VERSION
+                    data["schema_version"] = "1.1"
+                    skills_json_path.write_text(
+                        json.dumps(data, indent=2) + "\n", encoding="utf-8"
+                    )
+                    return True
+                except (json.JSONDecodeError, OSError):
+                    pass
+            return False
 
         skills_json_path = repo_path / "skills.json"
 
@@ -1382,8 +1404,9 @@ class SkillService:
             skills_json_path.write_text(
                 json.dumps(registry, indent=2) + "\n", encoding="utf-8"
             )
+            return True
         except OSError:
-            pass  # Don't fail the upgrade if skills.json can't be written
+            return False  # Don't fail the upgrade if skills.json can't be written
 
     def _write_registry_scaffold(self, repo_path: Path, repo_name: str) -> None:
         """Write the full skills registry scaffold with CI/CD automation.

--- a/tests/unit/interfaces/cli/test_skill_cmd.py
+++ b/tests/unit/interfaces/cli/test_skill_cmd.py
@@ -651,8 +651,9 @@ class TestSkillUpgradeRepoCommand:
         assert result.exit_code == 1
         assert "failed" in result.output.lower()
 
-    def test_upgrade_repo_default_path_is_cwd(self, tmp_path) -> None:
+    def test_upgrade_repo_default_path_is_cwd(self, tmp_path, monkeypatch) -> None:
         """Without PATH argument, defaults to current directory."""
+        monkeypatch.chdir(tmp_path)
         runner = CliRunner()
 
         result_data = Success(
@@ -669,13 +670,17 @@ class TestSkillUpgradeRepoCommand:
 
         assert result.exit_code == 0
         mock_cls.return_value.upgrade_registry_repo.assert_called_once()
+        # Verify the resolved path matches the cwd we set
+        call_args = mock_cls.return_value.upgrade_registry_repo.call_args
+        from pathlib import Path
 
-    def test_upgrade_repo_invalid_path_exits_nonzero(self) -> None:
+        assert call_args.args[0] == Path(tmp_path).resolve()
+
+    def test_upgrade_repo_invalid_path_exits_nonzero(self, tmp_path) -> None:
         """Non-existent path → Click error, exit != 0."""
         runner = CliRunner()
-        result = runner.invoke(
-            skill_group, ["upgrade-repo", "/nonexistent/path/to/repo"]
-        )
+        missing = str(tmp_path / "missing")
+        result = runner.invoke(skill_group, ["upgrade-repo", missing])
 
         assert result.exit_code != 0
 

--- a/tests/unit/interfaces/cli/test_skill_cmd.py
+++ b/tests/unit/interfaces/cli/test_skill_cmd.py
@@ -1,14 +1,15 @@
-"""Unit tests for skill CLI commands: outdated and upgrade."""
+"""Unit tests for skill CLI commands: outdated, upgrade, and upgrade-repo."""
 
 from __future__ import annotations
 
 from typing import List, Optional
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from click.testing import CliRunner
 
 from context_harness.interfaces.cli.skill_cmd import skill_group
 from context_harness.primitives import VersionStatus
+from context_harness.primitives.result import Success, Failure, ErrorCode
 from context_harness.primitives.skill import VersionComparison
 from context_harness.skills import SkillResult
 
@@ -482,3 +483,222 @@ class TestSkillInitRepoCommand:
         assert result.exit_code == 0
         mock_init.assert_called_once()
         assert mock_init.call_args.kwargs["name"] == "my-org/team-skills"
+
+
+# ---------------------------------------------------------------------------
+# skill upgrade-repo
+# ---------------------------------------------------------------------------
+
+
+class TestSkillUpgradeRepoCommand:
+    """Tests for `context-harness skill upgrade-repo`."""
+
+    def _patch_service(self, return_value):
+        """Helper to patch SkillService.upgrade_registry_repo."""
+        return patch(
+            "context_harness.services.skill_service.SkillService",
+            return_value=MagicMock(
+                upgrade_registry_repo=MagicMock(return_value=return_value)
+            ),
+        )
+
+    def test_upgrade_repo_success_upgraded(self, tmp_path) -> None:
+        """Successful upgrade → exit 0, 'upgraded' in output."""
+        runner = CliRunner()
+
+        result_data = Success(
+            value={
+                "upgraded": True,
+                "current_version": "0.0.0",
+                "latest_version": "1.1.0",
+                "files_updated": ["Dockerfile", ".registry-version"],
+            }
+        )
+
+        with self._patch_service(result_data):
+            result = runner.invoke(skill_group, ["upgrade-repo", str(tmp_path)])
+
+        assert result.exit_code == 0
+        assert "upgraded" in result.output.lower()
+
+    def test_upgrade_repo_success_shows_updated_files(self, tmp_path) -> None:
+        """Successful upgrade lists updated files in output."""
+        runner = CliRunner()
+
+        result_data = Success(
+            value={
+                "upgraded": True,
+                "current_version": "0.0.0",
+                "latest_version": "1.1.0",
+                "files_updated": ["Dockerfile", "docker-compose.yml"],
+            }
+        )
+
+        with self._patch_service(result_data):
+            result = runner.invoke(skill_group, ["upgrade-repo", str(tmp_path)])
+
+        assert result.exit_code == 0
+        assert "Dockerfile" in result.output
+        assert "docker-compose.yml" in result.output
+
+    def test_upgrade_repo_already_up_to_date(self, tmp_path) -> None:
+        """Registry already at latest version → exit 0, 'up to date' in output."""
+        runner = CliRunner()
+
+        result_data = Success(
+            value={
+                "upgraded": False,
+                "current_version": "1.1.0",
+                "latest_version": "1.1.0",
+            }
+        )
+
+        with self._patch_service(result_data):
+            result = runner.invoke(skill_group, ["upgrade-repo", str(tmp_path)])
+
+        assert result.exit_code == 0
+        assert "up to date" in result.output.lower()
+
+    def test_upgrade_repo_check_only_shows_available(self, tmp_path) -> None:
+        """--check flag shows available upgrade without applying."""
+        runner = CliRunner()
+
+        result_data = Success(
+            value={
+                "upgrade_available": True,
+                "current_version": "0.0.0",
+                "latest_version": "1.1.0",
+            }
+        )
+
+        with self._patch_service(result_data) as mock_cls:
+            result = runner.invoke(
+                skill_group, ["upgrade-repo", str(tmp_path), "--check"]
+            )
+
+        assert result.exit_code == 0
+        assert "available" in result.output.lower()
+        # Verify check_only was passed
+        mock_cls.return_value.upgrade_registry_repo.assert_called_once()
+        call_kwargs = mock_cls.return_value.upgrade_registry_repo.call_args
+        assert call_kwargs.kwargs.get("check_only") is True or (
+            len(call_kwargs.args) >= 2 and call_kwargs.args[1] is True
+        )
+
+    def test_upgrade_repo_dry_run_shows_files(self, tmp_path) -> None:
+        """--dry-run flag shows what would change without applying."""
+        runner = CliRunner()
+
+        result_data = Success(
+            value={
+                "dry_run": True,
+                "current_version": "0.0.0",
+                "latest_version": "1.1.0",
+                "files_to_update": ["Dockerfile", "registry/nginx.conf"],
+            }
+        )
+
+        with self._patch_service(result_data) as mock_cls:
+            result = runner.invoke(
+                skill_group, ["upgrade-repo", str(tmp_path), "--dry-run"]
+            )
+
+        assert result.exit_code == 0
+        assert "dry run" in result.output.lower()
+        assert "Dockerfile" in result.output
+        # Verify dry_run was passed
+        call_kwargs = mock_cls.return_value.upgrade_registry_repo.call_args
+        assert call_kwargs.kwargs.get("dry_run") is True or (
+            len(call_kwargs.args) >= 3 and call_kwargs.args[2] is True
+        )
+
+    def test_upgrade_repo_force_flag_passed(self, tmp_path) -> None:
+        """--force flag is passed through to the service."""
+        runner = CliRunner()
+
+        result_data = Success(
+            value={
+                "upgraded": True,
+                "current_version": "0.0.0",
+                "latest_version": "1.1.0",
+                "files_updated": ["Dockerfile"],
+            }
+        )
+
+        with self._patch_service(result_data) as mock_cls:
+            result = runner.invoke(
+                skill_group, ["upgrade-repo", str(tmp_path), "--force"]
+            )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_cls.return_value.upgrade_registry_repo.call_args
+        assert call_kwargs.kwargs.get("force") is True or (
+            len(call_kwargs.args) >= 4 and call_kwargs.args[3] is True
+        )
+
+    def test_upgrade_repo_failure_exits_1(self, tmp_path) -> None:
+        """Service failure → exit 1, error message in output."""
+        runner = CliRunner()
+
+        result_data = Failure(
+            error="Not a valid registry directory",
+            code=ErrorCode.VALIDATION_ERROR,
+        )
+
+        with self._patch_service(result_data):
+            result = runner.invoke(skill_group, ["upgrade-repo", str(tmp_path)])
+
+        assert result.exit_code == 1
+        assert "failed" in result.output.lower()
+
+    def test_upgrade_repo_default_path_is_cwd(self, tmp_path) -> None:
+        """Without PATH argument, defaults to current directory."""
+        runner = CliRunner()
+
+        result_data = Success(
+            value={
+                "upgraded": False,
+                "current_version": "1.1.0",
+                "latest_version": "1.1.0",
+            }
+        )
+
+        with self._patch_service(result_data) as mock_cls:
+            # Invoke without a path argument — Click uses default "."
+            result = runner.invoke(skill_group, ["upgrade-repo"])
+
+        assert result.exit_code == 0
+        mock_cls.return_value.upgrade_registry_repo.assert_called_once()
+
+    def test_upgrade_repo_invalid_path_exits_nonzero(self) -> None:
+        """Non-existent path → Click error, exit != 0."""
+        runner = CliRunner()
+        result = runner.invoke(
+            skill_group, ["upgrade-repo", "/nonexistent/path/to/repo"]
+        )
+
+        assert result.exit_code != 0
+
+    def test_upgrade_repo_combined_flags(self, tmp_path) -> None:
+        """--dry-run and --force can be combined."""
+        runner = CliRunner()
+
+        result_data = Success(
+            value={
+                "dry_run": True,
+                "current_version": "0.0.0",
+                "latest_version": "1.1.0",
+                "files_to_update": ["Dockerfile"],
+            }
+        )
+
+        with self._patch_service(result_data) as mock_cls:
+            result = runner.invoke(
+                skill_group,
+                ["upgrade-repo", str(tmp_path), "--dry-run", "--force"],
+            )
+
+        assert result.exit_code == 0
+        call_kwargs = mock_cls.return_value.upgrade_registry_repo.call_args
+        assert call_kwargs.kwargs.get("dry_run") is True
+        assert call_kwargs.kwargs.get("force") is True

--- a/tests/unit/services/test_skill_service.py
+++ b/tests/unit/services/test_skill_service.py
@@ -2033,3 +2033,171 @@ class TestSkillServiceUpgradeRegistryRepo:
         names = [s["name"] for s in data["skills"]]
         assert "alpha-skill" in names
         assert "beta-skill" in names
+
+    def test_upgrade_regenerates_skills_json_no_version_txt(
+        self, tmp_path: Path
+    ) -> None:
+        """Upgrade falls back to frontmatter version when version.txt is missing."""
+        service = SkillService(github_client=MockGitHubClient())
+
+        (tmp_path / "skills.json").write_text('{"skills": []}')
+        skill_dir = tmp_path / "skill" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: my-skill\ndescription: A skill\nversion: 2.5.0\n---\n# My Skill\n"
+        )
+        # No version.txt — should fall back to frontmatter version (2.5.0)
+
+        result = service.upgrade_registry_repo(tmp_path)
+        assert isinstance(result, Success)
+
+        data = json.loads((tmp_path / "skills.json").read_text())
+        assert data["skills"][0]["version"] == "2.5.0"
+
+    def test_upgrade_regenerates_skills_json_no_version_txt_no_frontmatter_version(
+        self, tmp_path: Path
+    ) -> None:
+        """Upgrade falls back to 0.1.0 when both version.txt and frontmatter version are missing."""
+        service = SkillService(github_client=MockGitHubClient())
+
+        (tmp_path / "skills.json").write_text('{"skills": []}')
+        skill_dir = tmp_path / "skill" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        # Frontmatter has no version field
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: my-skill\ndescription: A skill\n---\n# My Skill\n"
+        )
+
+        result = service.upgrade_registry_repo(tmp_path)
+        assert isinstance(result, Success)
+
+        data = json.loads((tmp_path / "skills.json").read_text())
+        assert data["skills"][0]["version"] == "0.1.0"
+
+    def test_upgrade_regenerates_skills_json_broken_frontmatter(
+        self, tmp_path: Path
+    ) -> None:
+        """Upgrade uses directory name as fallback when frontmatter is broken."""
+        service = SkillService(github_client=MockGitHubClient())
+
+        (tmp_path / "skills.json").write_text('{"skills": []}')
+        skill_dir = tmp_path / "skill" / "bad-skill"
+        skill_dir.mkdir(parents=True)
+        # Malformed SKILL.md with no closing frontmatter delimiter
+        (skill_dir / "SKILL.md").write_text("not valid frontmatter at all")
+        (skill_dir / "version.txt").write_text("3.0.0")
+
+        result = service.upgrade_registry_repo(tmp_path)
+        assert isinstance(result, Success)
+
+        data = json.loads((tmp_path / "skills.json").read_text())
+        assert len(data["skills"]) == 1
+        skill = data["skills"][0]
+        # Should fall back to directory name
+        assert skill["name"] == "bad-skill"
+        assert skill["version"] == "3.0.0"
+
+    def test_upgrade_regenerates_skills_json_empty_skill_dir(
+        self, tmp_path: Path
+    ) -> None:
+        """Upgrade produces empty skills array when skill/ has no subdirectories."""
+        service = SkillService(github_client=MockGitHubClient())
+
+        (tmp_path / "skills.json").write_text('{"skills": [{"id": "stale"}]}')
+        (tmp_path / "skill").mkdir()
+        # Empty skill/ directory — no subdirectories
+
+        result = service.upgrade_registry_repo(tmp_path)
+        assert isinstance(result, Success)
+
+        data = json.loads((tmp_path / "skills.json").read_text())
+        assert data["skills"] == []
+
+    def test_upgrade_regenerates_skills_json_top_level_fields(
+        self, tmp_path: Path
+    ) -> None:
+        """Upgrade sets schema_version and registry_version in skills.json."""
+        service = SkillService(github_client=MockGitHubClient())
+
+        (tmp_path / "skills.json").write_text('{"skills": []}')
+        skill_dir = tmp_path / "skill" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: my-skill\ndescription: A skill\n---\n# My Skill\n"
+        )
+        (skill_dir / "version.txt").write_text("1.0.0")
+
+        result = service.upgrade_registry_repo(tmp_path)
+        assert isinstance(result, Success)
+
+        data = json.loads((tmp_path / "skills.json").read_text())
+        assert data["schema_version"] == "1.1"
+        assert "registry_version" in data
+        assert len(data["registry_version"]) > 0
+
+    def test_upgrade_regenerates_skills_json_content_hash_deterministic(
+        self, tmp_path: Path
+    ) -> None:
+        """Content hash is deterministic for the same SKILL.md content."""
+        service = SkillService(github_client=MockGitHubClient())
+
+        skill_content = "---\nname: my-skill\ndescription: A skill\n---\n# My Skill\n"
+
+        (tmp_path / "skills.json").write_text('{"skills": []}')
+        skill_dir = tmp_path / "skill" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(skill_content)
+        (skill_dir / "version.txt").write_text("1.0.0")
+
+        # Run upgrade twice
+        service.upgrade_registry_repo(tmp_path)
+        data1 = json.loads((tmp_path / "skills.json").read_text())
+        hash1 = data1["skills"][0]["content_hash"]
+
+        service.upgrade_registry_repo(tmp_path)
+        data2 = json.loads((tmp_path / "skills.json").read_text())
+        hash2 = data2["skills"][0]["content_hash"]
+
+        assert hash1 == hash2
+        assert len(hash1) == 16  # SHA-256 truncated to 16 hex chars
+
+    def test_upgrade_regenerates_skills_json_with_min_ch_version(
+        self, tmp_path: Path
+    ) -> None:
+        """Upgrade includes min_context_harness_version when present in frontmatter."""
+        service = SkillService(github_client=MockGitHubClient())
+
+        (tmp_path / "skills.json").write_text('{"skills": []}')
+        skill_dir = tmp_path / "skill" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: my-skill\ndescription: A skill\n"
+            "min_context_harness_version: 3.5.0\n---\n# My Skill\n"
+        )
+        (skill_dir / "version.txt").write_text("1.0.0")
+
+        result = service.upgrade_registry_repo(tmp_path)
+        assert isinstance(result, Success)
+
+        data = json.loads((tmp_path / "skills.json").read_text())
+        assert data["skills"][0]["min_context_harness_version"] == "3.5.0"
+
+    def test_upgrade_regenerates_skills_json_without_min_ch_version(
+        self, tmp_path: Path
+    ) -> None:
+        """Upgrade omits min_context_harness_version when not in frontmatter."""
+        service = SkillService(github_client=MockGitHubClient())
+
+        (tmp_path / "skills.json").write_text('{"skills": []}')
+        skill_dir = tmp_path / "skill" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: my-skill\ndescription: A skill\n---\n# My Skill\n"
+        )
+        (skill_dir / "version.txt").write_text("1.0.0")
+
+        result = service.upgrade_registry_repo(tmp_path)
+        assert isinstance(result, Success)
+
+        data = json.loads((tmp_path / "skills.json").read_text())
+        assert "min_context_harness_version" not in data["skills"][0]

--- a/tests/unit/services/test_skill_service.py
+++ b/tests/unit/services/test_skill_service.py
@@ -2201,3 +2201,50 @@ class TestSkillServiceUpgradeRegistryRepo:
 
         data = json.loads((tmp_path / "skills.json").read_text())
         assert "min_context_harness_version" not in data["skills"][0]
+
+    def test_upgrade_regenerates_skills_json_included_in_files_updated(
+        self, tmp_path: Path
+    ) -> None:
+        """Upgrade includes skills.json in the files_updated list."""
+        service = SkillService(github_client=MockGitHubClient())
+
+        (tmp_path / "skills.json").write_text('{"skills": []}')
+        skill_dir = tmp_path / "skill" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: my-skill\ndescription: A skill\n---\n# My Skill\n"
+        )
+        (skill_dir / "version.txt").write_text("1.0.0")
+
+        result = service.upgrade_registry_repo(tmp_path)
+        assert isinstance(result, Success)
+        assert "skills.json" in result.value["files_updated"]
+
+    def test_upgrade_no_skill_dir_still_updates_skills_json_version(
+        self, tmp_path: Path
+    ) -> None:
+        """Without a skill/ directory, skills.json version markers are still updated."""
+        service = SkillService(github_client=MockGitHubClient())
+
+        # Pre-existing skills.json with stale version markers
+        (tmp_path / "skills.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "1.0",
+                    "registry_version": "0.0.0",
+                    "skills": [{"name": "existing-skill", "version": "1.0.0"}],
+                }
+            )
+        )
+        # No skill/ directory at all
+
+        result = service.upgrade_registry_repo(tmp_path)
+        assert isinstance(result, Success)
+
+        data = json.loads((tmp_path / "skills.json").read_text())
+        # Version markers should be updated
+        assert data["schema_version"] == "1.1"
+        assert data["registry_version"] != "0.0.0"
+        # Existing skills list should be preserved (not wiped)
+        assert len(data["skills"]) == 1
+        assert data["skills"][0]["name"] == "existing-skill"

--- a/tests/unit/services/test_skill_service.py
+++ b/tests/unit/services/test_skill_service.py
@@ -1238,7 +1238,9 @@ class TestSkillServiceInitRegistryRepo:
         for filepath in expected_files:
             assert (tmp_path / filepath).exists(), f"Missing: {filepath}"
 
-    def test_scaffold_llms_txt_contains_installation_instructions(self, tmp_path: Path) -> None:
+    def test_scaffold_llms_txt_contains_installation_instructions(
+        self, tmp_path: Path
+    ) -> None:
         """llms.txt contains AI agent installation protocol."""
         service = SkillService(github_client=MockGitHubClient())
         service._write_registry_scaffold(tmp_path, "test-user/my-skills")
@@ -1454,9 +1456,7 @@ class TestSkillServiceInitRegistryRepo:
         service = SkillService(github_client=MockGitHubClient())
         service._write_registry_scaffold(tmp_path, "test-user/my-skills")
 
-        content = (
-            tmp_path / ".github" / "workflows" / "auto-rebase.yml"
-        ).read_text()
+        content = (tmp_path / ".github" / "workflows" / "auto-rebase.yml").read_text()
         assert "Auto Rebase" in content
         assert "skills.json" in content
         assert "release-please-config.json" in content
@@ -1699,7 +1699,9 @@ class TestSkillServiceUpgradeRegistryRepo:
         service = SkillService(github_client=MockGitHubClient())
 
         # Create registry at current version
-        (tmp_path / ".registry-version").write_text("0.0.0")  # Will be older than CH_VERSION
+        (tmp_path / ".registry-version").write_text(
+            "0.0.0"
+        )  # Will be older than CH_VERSION
         (tmp_path / "skills.json").write_text('{"skills": []}')
         (tmp_path / "skill").mkdir()
 
@@ -1737,7 +1739,9 @@ class TestSkillServiceUpgradeRegistryRepo:
         (tmp_path / "skills.json").write_text('{"skills": []}')
         (tmp_path / "skill").mkdir()
         (tmp_path / ".github" / "workflows").mkdir(parents=True)
-        (tmp_path / ".github" / "workflows" / "release.yml").write_text("# OLD WORKFLOW")
+        (tmp_path / ".github" / "workflows" / "release.yml").write_text(
+            "# OLD WORKFLOW"
+        )
 
         result = service.upgrade_registry_repo(tmp_path, dry_run=True)
 
@@ -1921,7 +1925,9 @@ class TestSkillServiceUpgradeRegistryRepo:
         assert (tmp_path / "registry" / "nginx.conf").exists()
         assert (tmp_path / "registry" / "web" / "index.html").exists()
 
-    def test_upgrade_always_updates_critical_infrastructure(self, tmp_path: Path) -> None:
+    def test_upgrade_always_updates_critical_infrastructure(
+        self, tmp_path: Path
+    ) -> None:
         """Critical infrastructure is always updated, even without --force."""
         service = SkillService(github_client=MockGitHubClient())
 
@@ -1931,7 +1937,9 @@ class TestSkillServiceUpgradeRegistryRepo:
         (tmp_path / "skill").mkdir()
         (tmp_path / "Dockerfile").write_text("# OLD DOCKERFILE CONTENT")
         (tmp_path / ".github" / "workflows").mkdir(parents=True)
-        (tmp_path / ".github" / "workflows" / "release.yml").write_text("# OLD WORKFLOW")
+        (tmp_path / ".github" / "workflows" / "release.yml").write_text(
+            "# OLD WORKFLOW"
+        )
 
         # Without force, critical infrastructure should still be updated
         result_no_force = service.upgrade_registry_repo(tmp_path, dry_run=True)
@@ -1954,3 +1962,74 @@ class TestSkillServiceUpgradeRegistryRepo:
         # Everything is included with force
         assert "Dockerfile" in force_files
         assert ".github/workflows/release.yml" in force_files
+
+    def test_upgrade_regenerates_skills_json_with_full_metadata(
+        self, tmp_path: Path
+    ) -> None:
+        """Upgrade regenerates skills.json with name/description/version from SKILL.md."""
+        service = SkillService(github_client=MockGitHubClient())
+
+        # Create legacy registry with old-format skills.json (id-only entries)
+        (tmp_path / "skills.json").write_text(
+            json.dumps({"skills": [{"id": "my-skill"}]})
+        )
+        (tmp_path / "skill").mkdir()
+
+        # Create a skill directory with proper SKILL.md + version.txt
+        skill_dir = tmp_path / "skill" / "my-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: my-skill\ndescription: A test skill\ntags: [testing]\n---\n# My Skill\n"
+        )
+        (skill_dir / "version.txt").write_text("1.2.3")
+
+        result = service.upgrade_registry_repo(tmp_path)
+
+        assert isinstance(result, Success)
+
+        # Verify skills.json was regenerated with full metadata
+        data = json.loads((tmp_path / "skills.json").read_text())
+        assert len(data["skills"]) == 1
+
+        skill = data["skills"][0]
+        assert skill["name"] == "my-skill"
+        assert skill["description"] == "A test skill"
+        assert skill["version"] == "1.2.3"
+        assert skill["tags"] == ["testing"]
+        assert "path" in skill
+        assert "content_hash" in skill
+
+        # Old id-only format should be gone
+        assert "id" not in skill
+
+    def test_upgrade_regenerates_skills_json_multiple_skills(
+        self, tmp_path: Path
+    ) -> None:
+        """Upgrade regenerates skills.json with all skills from skill/ directory."""
+        service = SkillService(github_client=MockGitHubClient())
+
+        # Create legacy registry
+        (tmp_path / "skills.json").write_text('{"skills": [{"id": "old"}]}')
+        (tmp_path / "skill").mkdir()
+
+        # Create two skill directories
+        for name, desc, ver in [
+            ("alpha-skill", "First skill", "1.0.0"),
+            ("beta-skill", "Second skill", "2.0.0"),
+        ]:
+            d = tmp_path / "skill" / name
+            d.mkdir()
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {desc}\n---\n# {name}\n"
+            )
+            (d / "version.txt").write_text(ver)
+
+        result = service.upgrade_registry_repo(tmp_path)
+
+        assert isinstance(result, Success)
+        data = json.loads((tmp_path / "skills.json").read_text())
+        assert len(data["skills"]) == 2
+
+        names = [s["name"] for s in data["skills"]]
+        assert "alpha-skill" in names
+        assert "beta-skill" in names


### PR DESCRIPTION
## Summary

- **`_regenerate_skills_json()`** — new method in `SkillService` that scans `skill/` directories for SKILL.md frontmatter and `version.txt`, producing a full `skills.json` with `name`, `version`, `description`, `author`, `tags`, `content_hash`, and optional `min_context_harness_version`. Runs inline during `upgrade-repo` so `skills.json` is never stale.
- **`_update_json_version_markers()`** — narrowed to `marketplace.json` only; `skills.json` is handled by `_regenerate_skills_json()` to avoid redundant I/O.
- **Fallback for missing `skill/` directory** — when no `skill/` dir exists, `_regenerate_skills_json()` still updates `registry_version` and `schema_version` in any existing `skills.json`.
- **`files_updated` includes `skills.json`** — the return value of `upgrade_registry_repo()` now reports `skills.json` in the updated files list when it was rewritten.

## Why

The `upgrade-repo` command updated scaffold files but never regenerated `skills.json` from skill frontmatter. This left registries with stale id-only entries (`{"id": "example-skill"}`), which broke the web frontend that expects `name`, `version`, `description`, and `tags`.

## Tests

- 12 new tests for `_regenerate_skills_json()`: full metadata, multiple skills, missing `version.txt`, missing frontmatter version, broken frontmatter, empty `skill/` dir, top-level fields, content hash determinism, `min_context_harness_version` presence/absence, `skills.json` in `files_updated`, and no-`skill/`-dir version marker fallback.
- 2 improved CLI tests: `test_upgrade_repo_default_path_is_cwd` now uses `monkeypatch.chdir` and asserts the resolved path; `test_upgrade_repo_invalid_path_exits_nonzero` uses `tmp_path / "missing"` instead of a hardcoded absolute path.
- All 639 tests pass.