### PR TITLE
feat(cli): add Claude Code plugin marketplace, skill-onboarding agentic workflow, and comprehensive test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,19 @@ context-harness config set skills-repo your-org/your-skills
 context-harness config set skills-repo your-org/your-skills --user
 ```
 
+### Claude Code Plugin Marketplace
+
+Skills registries created with `ch skill init-repo` are also compatible with the [Claude Code plugin marketplace](https://code.claude.com/docs/en/plugin-marketplaces). Users can install skills via either tool:
+
+```bash
+# Via ContextHarness CLI
+ch skill install my-skill
+
+# Via Claude Code plugin marketplace
+/plugin marketplace add your-org/your-skills
+/plugin install my-skill@your-skills
+```
+
 ## Documentation
 
 - [Getting Started](docs/getting-started/) - Step-by-step guides

--- a/docs/SCAFFOLD_UPGRADE.md
+++ b/docs/SCAFFOLD_UPGRADE.md
@@ -66,6 +66,10 @@ They are **always updated** during upgrade, even without `--force`.
 | `Dockerfile` | `_write_scaffold_dockerfile` | Contains COPY paths that must match file locations |
 | `docker-compose.yml` | `_write_scaffold_docker_compose` | Volume mounts and service config |
 | `registry/nginx.conf` | `_write_scaffold_nginx_conf` | Nginx config for serving files |
+| `registry/web/index.html` | `_write_scaffold_index_html` | AI agent instructions updated regularly |
+| `registry/web/skill.html` | `_write_scaffold_skill_html` | Skill detail page format may change |
+| `llms.txt` | `_write_scaffold_llms_txt` | AI agent installation protocol |
+| `.github/workflows/skill-onboarding.md` | `_write_scaffold_skill_onboarding_workflow` | Agentic workflow instructions updated regularly |
 
 ### Infrastructure Files (added if missing, or with --force)
 | File | Writer Method | Notes |
@@ -73,7 +77,6 @@ They are **always updated** during upgrade, even without `--force`.
 | `.github/workflows/release.yml` | `_write_scaffold_release_workflow` | Release automation |
 | `.github/workflows/sync-registry.yml` | `_write_scaffold_sync_registry_workflow` | Post-release sync |
 | `.github/workflows/validate-skills.yml` | `_write_scaffold_validate_skills_workflow` | Skill validation |
-| `.github/workflows/auto-rebase.yml` | `_write_scaffold_auto_rebase_workflow` | Auto PR rebase |
 | `.github/ISSUE_TEMPLATE/new-skill.md` | `_write_scaffold_issue_template` | Skill request template |
 | `.github/PULL_REQUEST_TEMPLATE.md` | `_write_scaffold_pr_template` | PR template |
 | `scripts/sync-registry.py` | `_write_scaffold_sync_registry_script` | Registry sync script |

--- a/docs/SCAFFOLD_UPGRADE.md
+++ b/docs/SCAFFOLD_UPGRADE.md
@@ -84,6 +84,7 @@ They are **always updated** during upgrade, even without `--force`.
 | `.release-please-manifest.json` | `_write_scaffold_release_please_manifest` | Version manifest |
 | `.gitignore` | `_write_scaffold_gitignore` | Git ignore rules |
 | `marketplace.json` | `_write_scaffold_marketplace_json` | Plugin discovery manifest |
+| `.claude-plugin/marketplace.json` | `_write_scaffold_claude_plugin_marketplace` | Claude Code plugin marketplace |
 
 ### Documentation Files (only if missing or with --force)
 | File | Writer Method | Notes |
@@ -98,6 +99,7 @@ They are **always updated** during upgrade, even without `--force`.
 | `.registry-version` | `_write_scaffold_registry_version` | Always updated |
 | `skills.json` | `_write_scaffold_skills_json` | Version markers only |
 | `skill/*` | Various | User-owned, never touched |
+| `skill/*/.claude-plugin/plugin.json` | `_write_scaffold_skill_plugin_json` | Auto-generated per skill |
 
 ## Upgrade Behavior
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -353,7 +353,7 @@ All agent behaviors are defined in markdown files:
 
 ### Skills Registry Architecture
 
-The skills system uses a distributed registry model where repositories host skills and a CLI fetches them:
+The skills system uses a distributed registry model where repositories host skills and clients fetch them via multiple channels:
 
 ```
 ┌──────────────────────┐     ┌──────────────────────────────────────┐
@@ -363,14 +363,23 @@ The skills system uses a distributed registry model where repositories host skil
 │  • skill install     │     │  skill/*/SKILL.md                    │
 │  • skill outdated    │     │  skill/*/version.txt ◀── release.yml │
 │  • skill upgrade     │     │                                      │
-└──────────────────────┘     └──────────────────────────────────────┘
+└──────────────────────┘     │  .claude-plugin/marketplace.json     │
+                             │  skill/*/.claude-plugin/plugin.json  │
+┌──────────────────────┐     │                                      │
+│  Claude Code          │────▶│  (Claude Code plugin marketplace     │
+│                      │     │   standard for /plugin install)      │
+│  • /plugin add       │     │                                      │
+│  • /plugin install   │     └──────────────────────────────────────┘
+└──────────────────────┘
 ```
 
 Repositories scaffolded by `ch skill init-repo` include CI/CD automation:
 
 - **release-please** manages per-skill `version.txt` and `CHANGELOG.md` via conventional commits
-- **sync-registry** rebuilds `skills.json` from frontmatter + `version.txt` after each release
+- **sync-registry** rebuilds `skills.json`, `.claude-plugin/marketplace.json`, and per-skill `plugin.json` after each release
 - **validate-skills** checks PR changes for schema compliance
+
+The dual-format marketplace enables installation via either `ch skill install <name>` (ContextHarness CLI) or `/plugin marketplace add owner/repo` followed by `/plugin install <name>@marketplace` (Claude Code).
 
 See [Skills Guide](../user-guide/skills.md#automated-versioning) for the full versioning lifecycle.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -232,6 +232,8 @@ ch skill init-repo my-org/skills -d "Team AI skills"  # With custom description
 
 ```
 my-skills/
+├── .claude-plugin/
+│   └── marketplace.json              # Claude Code plugin marketplace
 ├── .github/
 │   ├── workflows/
 │   │   ├── release.yml              # release-please per-skill versioning
@@ -245,9 +247,12 @@ my-skills/
 │   └── validate_skills.py           # Pydantic-based validation
 ├── skill/
 │   └── example-skill/
+│       ├── .claude-plugin/
+│       │   └── plugin.json          # Claude Code plugin manifest
 │       ├── SKILL.md
 │       └── version.txt              # Bootstrapped at 0.1.0
 ├── skills.json
+├── marketplace.json                 # ContextHarness marketplace manifest
 ├── release-please-config.json
 ├── .release-please-manifest.json
 ├── .gitignore
@@ -256,7 +261,7 @@ my-skills/
 └── QUICKSTART.md
 ```
 
-For details on the CI/CD automation and versioning lifecycle, see [Automated Versioning](../user-guide/skills.md#automated-versioning).
+The registry is compatible with both **ContextHarness CLI** (`ch skill install`) and **Claude Code plugin marketplace** (`/plugin marketplace add`). See [Claude Code Plugin Marketplace](../user-guide/skills.md#claude-code-plugin-marketplace) for details.
 
 **Options:**
 
@@ -366,6 +371,7 @@ ch skill upgrade-repo --force      # Overwrite all scaffold files
 | Category | Files | Behavior |
 |----------|-------|----------|
 | Critical infrastructure | Dockerfile, docker-compose.yml, nginx.conf, index.html, skill.html, llms.txt | Always updated |
+| Plugin marketplace | .claude-plugin/marketplace.json | Always updated |
 | Workflows | release.yml, sync-registry.yml, validate-skills.yml, auto-rebase.yml | Only if missing |
 | Documentation | README.md, CONTRIBUTING.md, QUICKSTART.md | Only if missing |
 

--- a/docs/user-guide/skills.md
+++ b/docs/user-guide/skills.md
@@ -247,6 +247,8 @@ The command creates a fully scaffolded repository with CI/CD automation for per-
 
 ```
 my-skills/
+├── .claude-plugin/
+│   └── marketplace.json               # Claude Code plugin marketplace manifest
 ├── .github/
 │   ├── workflows/
 │   │   ├── release.yml                # release-please per-skill versioning
@@ -260,9 +262,12 @@ my-skills/
 │   └── validate_skills.py             # Pydantic-based schema validation
 ├── skill/
 │   └── example-skill/
+│       ├── .claude-plugin/
+│       │   └── plugin.json            # Claude Code plugin manifest
 │       ├── SKILL.md                   # Example skill (no version in frontmatter)
 │       └── version.txt                # Bootstrapped at 0.1.0
 ├── skills.json                        # Registry manifest (auto-updated by CI)
+├── marketplace.json                   # ContextHarness marketplace manifest
 ├── release-please-config.json         # release-please configuration
 ├── .release-please-manifest.json      # Current versions (managed by CI)
 ├── .gitignore
@@ -271,8 +276,8 @@ my-skills/
 └── QUICKSTART.md                      # Quick-start for adding your first skill
 ```
 
-!!! info "16 Files, Zero Manual Setup"
-    The scaffold creates 16 files — a complete GitHub repository with CI/CD that handles versioning, validation, and registry updates automatically. You just write skill content and use conventional commits.
+!!! info "Dual Marketplace Format"
+    The scaffold creates both a ContextHarness-native `marketplace.json` (for `ch skill install`) and a Claude Code plugin marketplace at `.claude-plugin/marketplace.json` (for `/plugin marketplace add`). Users can install skills via either tool. See [Claude Code Plugin Marketplace](#claude-code-plugin-marketplace) below.
 
 Once created, you can start adding skills to the repository. See [Adding Skills to Your Registry](#adding-skills-to-your-registry) below for the complete workflow.
 
@@ -322,6 +327,8 @@ A skills registry repository follows this structure:
 
 ```
 my-skills-repo/
+├── .claude-plugin/
+│   └── marketplace.json             # Claude Code plugin marketplace
 ├── .github/
 │   └── workflows/
 │       ├── release.yml              # Automated per-skill releases
@@ -332,12 +339,17 @@ my-skills-repo/
 │   └── validate_skills.py           # Validation script
 ├── skill/                           # All skills live here
 │   ├── my-skill/
+│   │   ├── .claude-plugin/
+│   │   │   └── plugin.json          # Claude Code plugin manifest
 │   │   ├── SKILL.md                 # Skill content (no version in frontmatter)
 │   │   └── version.txt              # Current version (managed by release-please)
 │   └── another-skill/
+│       ├── .claude-plugin/
+│       │   └── plugin.json
 │       ├── SKILL.md
 │       └── version.txt
 ├── skills.json                      # Registry manifest (auto-generated)
+├── marketplace.json                 # ContextHarness marketplace manifest
 ├── release-please-config.json       # Versioning configuration
 ├── .release-please-manifest.json    # Version state
 ├── README.md
@@ -478,7 +490,9 @@ Fires after a release is published. Runs `scripts/sync-registry.py` to:
 2. Read `version.txt` from each skill directory
 3. Compute content hashes for change detection
 4. Write the consolidated `skills.json`
-5. Commit with `[skip ci]` to prevent infinite loops
+5. Update `.claude-plugin/marketplace.json` with current plugin entries
+6. Update per-skill `.claude-plugin/plugin.json` manifests
+7. Commit with `[skip ci]` to prevent infinite loops
 
 #### `validate-skills.yml` — PR Validation
 
@@ -625,6 +639,106 @@ Use `--force` to bypass the check if needed:
 ch skill upgrade react-forms --force
 ```
 
+## Claude Code Plugin Marketplace
+
+Skills registries created or upgraded with ContextHarness are fully compatible with the [Claude Code plugin marketplace standard](https://code.claude.com/docs/en/plugin-marketplaces). Each skill is an individually installable plugin, giving users a choice between the ContextHarness CLI or Claude Code's built-in plugin system.
+
+### How It Works
+
+Every registry includes two marketplace formats:
+
+| File | Format | Used By |
+|------|--------|---------|
+| `marketplace.json` | ContextHarness-native | `ch skill install` |
+| `.claude-plugin/marketplace.json` | Claude Code standard | `/plugin marketplace add` |
+
+Each skill directory also includes `.claude-plugin/plugin.json` — a Claude Code plugin manifest that enables individual skill installation.
+
+Both formats are automatically kept in sync by the `sync-registry.yml` CI workflow after each release.
+
+### Installing via Claude Code
+
+Add the registry as a Claude Code plugin marketplace:
+
+```bash
+# Add the marketplace (one time)
+/plugin marketplace add owner/repo
+
+# Browse available plugins
+/plugin list
+
+# Install a specific skill as a plugin
+/plugin install my-skill@repo-name
+```
+
+Skills installed this way are available as `/my-skill` commands inside Claude Code sessions.
+
+### Installing via ContextHarness CLI
+
+The traditional CLI workflow also continues to work:
+
+```bash
+# Configure the registry
+ch config set skills-repo owner/repo
+
+# Install a skill
+ch skill install my-skill
+```
+
+### Marketplace Schema
+
+The `.claude-plugin/marketplace.json` follows the Claude Code plugin marketplace specification:
+
+```json
+{
+  "name": "repo-name",
+  "owner": {
+    "name": "owner"
+  },
+  "metadata": {
+    "description": "repo-name skills registry",
+    "version": "0.8.0",
+    "pluginRoot": "./skill"
+  },
+  "plugins": [
+    {
+      "name": "my-skill",
+      "source": "./skill/my-skill",
+      "description": "What this skill does",
+      "version": "1.2.0"
+    }
+  ]
+}
+```
+
+Each skill's `.claude-plugin/plugin.json` contains:
+
+```json
+{
+  "name": "my-skill",
+  "description": "What this skill does",
+  "version": "1.2.0"
+}
+```
+
+!!! tip "Team Distribution"
+    For team-wide distribution, add the marketplace to your project's `.claude/settings.json`:
+
+    ```json
+    {
+      "extraKnownMarketplaces": {
+        "repo-name": {
+          "source": {
+            "source": "github",
+            "repo": "your-org/your-skills"
+          }
+        }
+      }
+    }
+    ```
+
+    Team members will be prompted to install the marketplace when they trust the project folder.
+
 ## HTTP Registry Hosting
 
 Skills registries can be hosted via HTTP (no Git required) using Docker and nginx. This is useful for:
@@ -700,6 +814,7 @@ ch skill upgrade-repo --force
 The command updates:
 
 - **Critical infrastructure** - Always updated: Dockerfile, nginx.conf, index.html, skill.html, llms.txt
+- **Claude Code plugin marketplace** - Always updated: `.claude-plugin/marketplace.json`
 - **Documentation** - Only if missing (use `--force` to overwrite)
 - **Workflows** - Only if missing (use `--force` to overwrite)
 

--- a/src/context_harness/services/skill_service.py
+++ b/src/context_harness/services/skill_service.py
@@ -1113,6 +1113,8 @@ class SkillService:
             ".gitignore",
             # Marketplace manifest
             "marketplace.json",
+            # Claude Code plugin marketplace
+            ".claude-plugin/marketplace.json",
         ]
 
         # Documentation files - often customized by users
@@ -1268,6 +1270,10 @@ class SkillService:
             "marketplace.json": lambda p: self._write_scaffold_marketplace_json(
                 p, repo_name
             ),
+            # Claude Code plugin marketplace (requires repo_name)
+            ".claude-plugin/marketplace.json": lambda p: (
+                self._write_scaffold_claude_plugin_marketplace(p, repo_name)
+            ),
             # Documentation (requires repo_name)
             "README.md": lambda p: self._write_scaffold_readme(p, repo_name),
             "CONTRIBUTING.md": lambda p: self._write_scaffold_contributing(
@@ -1283,13 +1289,13 @@ class SkillService:
             self._write_scaffold_registry_version(repo_path)
 
     def _update_json_version_markers(self, repo_path: Path) -> None:
-        """Update registry_version in marketplace.json.
+        """Update registry_version in marketplace.json and .claude-plugin/marketplace.json.
 
         Note: skills.json is handled by _regenerate_skills_json() which
         rewrites the file from scratch during upgrade-repo, so we skip it
         here to avoid redundant I/O.
         """
-        # Update marketplace.json
+        # Update marketplace.json (ContextHarness-native format)
         marketplace_path = repo_path / "marketplace.json"
         if marketplace_path.exists():
             try:
@@ -1297,6 +1303,20 @@ class SkillService:
                 data["registry_version"] = CH_VERSION
                 data["schema_version"] = "1.1"
                 marketplace_path.write_text(
+                    json.dumps(data, indent=2) + "\n", encoding="utf-8"
+                )
+            except (json.JSONDecodeError, KeyError):
+                pass
+
+        # Update .claude-plugin/marketplace.json (Claude Code standard)
+        claude_mkt_path = repo_path / ".claude-plugin" / "marketplace.json"
+        if claude_mkt_path.exists():
+            try:
+                data = json.loads(claude_mkt_path.read_text(encoding="utf-8"))
+                if "metadata" not in data:
+                    data["metadata"] = {}
+                data["metadata"]["version"] = CH_VERSION
+                claude_mkt_path.write_text(
                     json.dumps(data, indent=2) + "\n", encoding="utf-8"
                 )
             except (json.JSONDecodeError, KeyError):
@@ -1471,6 +1491,15 @@ class SkillService:
 
         # --- Marketplace manifest for plugin discovery ---
         self._write_scaffold_marketplace_json(repo_path, repo_name)
+
+        # --- Claude Code plugin marketplace (per-skill plugins) ---
+        self._write_scaffold_claude_plugin_marketplace(repo_path, repo_name)
+        # Write .claude-plugin/plugin.json for each skill directory
+        skills_dir = repo_path / "skill"
+        if skills_dir.exists():
+            for skill_dir in sorted(skills_dir.iterdir()):
+                if skill_dir.is_dir() and (skill_dir / "SKILL.md").exists():
+                    self._write_scaffold_skill_plugin_json(skill_dir)
 
         # --- Registry version marker (for upgrade detection) ---
         self._write_scaffold_registry_version(repo_path)
@@ -1697,6 +1726,23 @@ context-harness skill use-registry http://localhost:8080
 context-harness skill install <skill-name> --registry http://localhost:8080
 ```
 
+## Claude Code Plugin Marketplace
+
+This registry is also a **Claude Code plugin marketplace**. Each skill is an
+individually installable plugin, so you can use either the ContextHarness CLI
+or Claude Code's built-in plugin system:
+
+```bash
+# Add as a Claude Code plugin marketplace
+/plugin marketplace add {repo_name}
+
+# Install a specific skill as a Claude Code plugin
+/plugin install <skill-name>@{repo_name.split("/")[-1]}
+```
+
+Skills installed via Claude Code are available as `/skill-name` commands
+inside Claude Code sessions.
+
 ## Commit Convention
 
 | Commit prefix | Version bump | Example |
@@ -1711,6 +1757,8 @@ context-harness skill install <skill-name> --registry http://localhost:8080
 
 ```
 {repo_name}/
+├── .claude-plugin/
+│   └── marketplace.json          # Claude Code plugin marketplace manifest
 ├── .github/
 │   └── workflows/
 │       ├── release.yml           # release-please automation
@@ -1727,13 +1775,15 @@ context-harness skill install <skill-name> --registry http://localhost:8080
 │       └── skill.html            # Individual skill pages
 ├── skill/
 │   └── example-skill/
+│       ├── .claude-plugin/
+│       │   └── plugin.json       # Claude Code plugin manifest
 │       ├── SKILL.md              # Skill content (no version field)
 │       └── version.txt           # Managed by release-please
 ├── Dockerfile                    # nginx container for HTTP hosting
 ├── docker-compose.yml            # Easy local deployment
 ├── llms.txt                      # AI agent installation instructions
 ├── skills.json                   # Auto-maintained registry manifest
-├── marketplace.json              # Plugin marketplace compatibility
+├── marketplace.json              # ContextHarness marketplace manifest
 ├── release-please-config.json    # Per-skill release configuration
 ├── .release-please-manifest.json # Current versions (CI-managed)
 ├── CONTRIBUTING.md
@@ -1819,6 +1869,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for how to add or update skills.
 
 - **Never edit `version.txt` manually** — release-please manages it
 - **Never edit `skills.json` manually** — CI rebuilds it after releases
+- **Never edit `.claude-plugin/` files manually** — CI regenerates them after releases
 - **Never add `version` to SKILL.md frontmatter** — it lives in `version.txt`
 - The `name` field in SKILL.md **must match** the directory name
 """
@@ -1908,12 +1959,24 @@ git push origin main
 
 ## Install Your Skill
 
+### Via ContextHarness CLI
+
 ```bash
 # Configure this registry (one time)
 context-harness config set skills-repo {repo_name}
 
 # Install
 context-harness skill install my-first-skill
+```
+
+### Via Claude Code Plugin Marketplace
+
+```bash
+# Add this registry as a Claude Code plugin marketplace (one time)
+/plugin marketplace add {repo_name}
+
+# Install
+/plugin install my-first-skill@{repo_name.split("/")[-1]}
 ```
 """
         (repo_path / "QUICKSTART.md").write_text(content, encoding="utf-8")
@@ -2045,7 +2108,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add skills.json marketplace.json skill/*/.listing.json
+           git add skills.json marketplace.json .claude-plugin/marketplace.json skill/*/.listing.json skill/*/.claude-plugin/plugin.json
           git diff --cached --quiet || git commit -m "chore: sync registry manifests [skip ci]"
           git push
 """
@@ -2464,8 +2527,95 @@ def update_marketplace_json(skills: list) -> None:
     print(f"Updated marketplace.json with {len(skills)} skill(s)")
 
 
+def update_claude_plugin_marketplace(skills: list) -> None:
+    """Update .claude-plugin/marketplace.json (Claude Code plugin marketplace standard).
+
+    Generates a marketplace.json conforming to the Claude Code plugin
+    marketplace specification so the registry can also be added via:
+
+        /plugin marketplace add owner/repo
+        /plugin install skill-name@marketplace-name
+
+    Each skill becomes an individually installable plugin entry.
+    """
+    import os
+
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    parts = repo.split("/") if repo else []
+    owner = parts[0] if len(parts) == 2 else ""
+    name = parts[1] if len(parts) == 2 else ""
+
+    # Load existing .claude-plugin/marketplace.json to preserve owner metadata
+    claude_mkt_path = Path(".claude-plugin/marketplace.json")
+    if claude_mkt_path.exists():
+        try:
+            existing = json.loads(claude_mkt_path.read_text())
+        except json.JSONDecodeError:
+            existing = {}
+    else:
+        existing = {}
+
+    # Build plugin entries from skills
+    plugins = []
+    for skill in skills:
+        plugin_entry = {
+            "name": skill["name"],
+            "source": f"./skill/{skill['path'].split('/')[-1]}" if "/" in skill.get("path", "") else f"./skill/{skill['name']}",
+            "description": skill.get("description", ""),
+            "version": skill.get("version", "0.1.0"),
+        }
+        plugins.append(plugin_entry)
+
+    marketplace = {
+        "name": existing.get("name", name or repo),
+        "owner": existing.get("owner", {"name": owner or "Registry Owner"}),
+        "metadata": {
+            "description": existing.get("metadata", {}).get(
+                "description",
+                f"{name or repo} skills registry — "
+                "installable via ContextHarness CLI or Claude Code plugins",
+            ),
+            "version": get_registry_version(),
+            "pluginRoot": "./skill",
+        },
+        "plugins": plugins,
+    }
+
+    claude_mkt_path.parent.mkdir(parents=True, exist_ok=True)
+    claude_mkt_path.write_text(
+        json.dumps(marketplace, indent=2) + "\\n", encoding="utf-8"
+    )
+    print(f"Updated .claude-plugin/marketplace.json with {len(plugins)} plugin(s)")
+
+
+def update_skill_plugin_json(skills: list) -> None:
+    """Write .claude-plugin/plugin.json for each skill directory.
+
+    Each skill gets a Claude Code plugin manifest so it can be installed
+    individually via the Claude Code plugin marketplace.
+    """
+    for skill in skills:
+        skill_path = Path(skill.get("path", f"skill/{skill['name']}"))
+        if not skill_path.exists():
+            continue
+
+        plugin_manifest = {
+            "name": skill["name"],
+            "description": skill.get("description", ""),
+            "version": skill.get("version", "0.1.0"),
+        }
+
+        plugin_dir = skill_path / ".claude-plugin"
+        plugin_dir.mkdir(parents=True, exist_ok=True)
+        (plugin_dir / "plugin.json").write_text(
+            json.dumps(plugin_manifest, indent=2) + "\\n", encoding="utf-8"
+        )
+
+    print(f"Updated .claude-plugin/plugin.json for {len(skills)} skill(s)")
+
+
 def main() -> None:
-    """Rebuild and write skills.json and marketplace.json."""
+    """Rebuild and write skills.json, marketplace.json, and Claude Code plugin manifests."""
     registry = build_registry()
 
     Path("skills.json").write_text(
@@ -2476,8 +2626,12 @@ def main() -> None:
     for skill in registry["skills"]:
         print(f"  - {skill['name']} v{skill['version']}")
 
-    # Also update marketplace.json
+    # Also update marketplace.json (ContextHarness-native format)
     update_marketplace_json(registry["skills"])
+
+    # Update Claude Code plugin marketplace manifests
+    update_claude_plugin_marketplace(registry["skills"])
+    update_skill_plugin_json(registry["skills"])
 
 
 if __name__ == "__main__":
@@ -3455,6 +3609,134 @@ python scripts/validate_skills.py
         }
         (repo_path / "marketplace.json").write_text(
             json.dumps(marketplace, indent=2) + "\n", encoding="utf-8"
+        )
+
+    def _write_scaffold_claude_plugin_marketplace(
+        self, repo_path: Path, repo_name: str
+    ) -> None:
+        """Write .claude-plugin/marketplace.json — Claude Code plugin marketplace.
+
+        Generates a marketplace.json conforming to the Claude Code plugin
+        marketplace standard (https://code.claude.com/docs/en/plugin-marketplaces).
+        Each skill directory is listed as an individual plugin with a relative
+        path source, enabling per-skill installation via:
+
+            /plugin marketplace add owner/repo
+            /plugin install skill-name@marketplace-name
+
+        The marketplace is regenerated by sync-registry.py alongside the
+        ContextHarness-native marketplace.json whenever skills are updated.
+        """
+        parts = repo_name.split("/")
+        if len(parts) == 2:
+            owner, name = parts
+        else:
+            owner = repo_name
+            name = repo_name
+
+        # Build plugin entries from existing skill directories
+        plugins: list[dict[str, Any]] = []
+        skills_dir = repo_path / "skill"
+        if skills_dir.exists():
+            for skill_dir in sorted(skills_dir.iterdir()):
+                if not skill_dir.is_dir():
+                    continue
+                skill_md = skill_dir / "SKILL.md"
+                if not skill_md.exists():
+                    continue
+
+                # Parse skill metadata from SKILL.md frontmatter
+                description = ""
+                skill_name = skill_dir.name
+                version = "0.1.0"
+                try:
+                    content = skill_md.read_text(encoding="utf-8")
+                    if content.startswith("---"):
+                        end = content.index("---", 3)
+                        import yaml
+
+                        fm = yaml.safe_load(content[3:end])
+                        if isinstance(fm, dict):
+                            description = fm.get("description", "")
+                            skill_name = fm.get("name", skill_dir.name)
+                except Exception:
+                    pass
+
+                version_txt = skill_dir / "version.txt"
+                if version_txt.exists():
+                    version = version_txt.read_text(encoding="utf-8").strip()
+
+                plugin_entry: dict[str, Any] = {
+                    "name": skill_name,
+                    "source": f"./skill/{skill_dir.name}",
+                    "description": description,
+                    "version": version,
+                }
+                plugins.append(plugin_entry)
+
+        marketplace = {
+            "name": name,
+            "owner": {
+                "name": owner,
+            },
+            "metadata": {
+                "description": f"{name} skills registry — "
+                f"installable via ContextHarness CLI or Claude Code plugins",
+                "version": CH_VERSION,
+                "pluginRoot": "./skill",
+            },
+            "plugins": plugins,
+        }
+
+        claude_plugin_dir = repo_path / ".claude-plugin"
+        claude_plugin_dir.mkdir(parents=True, exist_ok=True)
+        (claude_plugin_dir / "marketplace.json").write_text(
+            json.dumps(marketplace, indent=2) + "\n", encoding="utf-8"
+        )
+
+    def _write_scaffold_skill_plugin_json(self, skill_path: Path) -> None:
+        """Write .claude-plugin/plugin.json for a skill directory.
+
+        Each skill directory gets a Claude Code plugin manifest so it can
+        be installed individually via the Claude Code plugin marketplace.
+        The plugin exposes the skill's SKILL.md as a Claude Code skill.
+
+        Args:
+            skill_path: Path to the skill directory (e.g., skill/example-skill/)
+        """
+        skill_md = skill_path / "SKILL.md"
+
+        # Extract metadata from SKILL.md frontmatter
+        skill_name = skill_path.name
+        description = ""
+        try:
+            content = skill_md.read_text(encoding="utf-8")
+            if content.startswith("---"):
+                end = content.index("---", 3)
+                import yaml
+
+                fm = yaml.safe_load(content[3:end])
+                if isinstance(fm, dict):
+                    skill_name = fm.get("name", skill_path.name)
+                    description = fm.get("description", "")
+        except Exception:
+            pass
+
+        version = "0.1.0"
+        version_txt = skill_path / "version.txt"
+        if version_txt.exists():
+            version = version_txt.read_text(encoding="utf-8").strip()
+
+        plugin_manifest = {
+            "name": skill_name,
+            "description": description,
+            "version": version,
+        }
+
+        plugin_dir = skill_path / ".claude-plugin"
+        plugin_dir.mkdir(parents=True, exist_ok=True)
+        (plugin_dir / "plugin.json").write_text(
+            json.dumps(plugin_manifest, indent=2) + "\n", encoding="utf-8"
         )
 
     def _write_scaffold_http_registry(self, repo_path: Path, repo_name: str) -> None:

--- a/src/context_harness/services/skill_service.py
+++ b/src/context_harness/services/skill_service.py
@@ -1043,6 +1043,17 @@ class SkillService:
             if "skills.json" not in updated_files:
                 updated_files.append("skills.json")
 
+        # Regenerate per-skill .claude-plugin/plugin.json for all skills
+        # These may be missing in registries created before Claude Code support
+        skills_dir = repo_path / "skill"
+        if skills_dir.exists():
+            for skill_dir in sorted(skills_dir.iterdir()):
+                if skill_dir.is_dir() and (skill_dir / "SKILL.md").exists():
+                    self._write_scaffold_skill_plugin_json(skill_dir)
+                    rel = f"skill/{skill_dir.name}/.claude-plugin/plugin.json"
+                    if rel not in updated_files:
+                        updated_files.append(rel)
+
         return Success(
             value={
                 "current_version": current_version,

--- a/src/context_harness/services/skill_service.py
+++ b/src/context_harness/services/skill_service.py
@@ -1035,6 +1035,16 @@ class SkillService:
             repo_path, files_to_update, force=force
         )
 
+        # Remove obsolete scaffold files replaced by newer equivalents
+        obsolete_files = [
+            ".github/workflows/auto-rebase.yml",  # Replaced by skill-onboarding.md
+        ]
+        for obsolete in obsolete_files:
+            obsolete_path = repo_path / obsolete
+            if obsolete_path.exists():
+                obsolete_path.unlink()
+                updated_files.append(f"(removed) {obsolete}")
+
         # Attempt to compile agentic workflows if the .md file was updated
         if any(f.endswith(".md") and "workflows" in f for f in updated_files):
             self._try_compile_agentic_workflows(repo_path)
@@ -1191,6 +1201,7 @@ class SkillService:
             "registry/web/index.html",  # AI agent instructions are updated regularly
             "registry/web/skill.html",  # Skill detail page format may change
             "llms.txt",  # AI agent installation protocol (emerging standard)
+            ".github/workflows/skill-onboarding.md",  # Agentic workflow instructions updated regularly
         }
 
         updated_files = []

--- a/src/context_harness/services/skill_service.py
+++ b/src/context_harness/services/skill_service.py
@@ -2246,6 +2246,7 @@ on:
       - "skill/**"
 tools:
   github:
+    toolsets: [context, repos, pull_requests]
   edit:
   bash: true
 safe-outputs:

--- a/src/context_harness/services/skill_service.py
+++ b/src/context_harness/services/skill_service.py
@@ -880,6 +880,9 @@ class SkillService:
                 # Write scaffold files
                 self._write_registry_scaffold(tmppath, name)
 
+                # Attempt to compile the agentic workflow (requires gh-aw extension)
+                self._try_compile_agentic_workflows(tmppath)
+
                 # Stage, commit, and push
                 subprocess.run(
                     ["git", "-C", tmpdir, "add", "."],
@@ -1032,6 +1035,10 @@ class SkillService:
             repo_path, files_to_update, force=force
         )
 
+        # Attempt to compile agentic workflows if the .md file was updated
+        if any(f.endswith(".md") and "workflows" in f for f in updated_files):
+            self._try_compile_agentic_workflows(repo_path)
+
         # Update version markers
         self._write_scaffold_registry_version(repo_path)
         self._update_json_version_markers(repo_path)
@@ -1102,6 +1109,7 @@ class SkillService:
             "registry/web/index.html",  # AI agent instructions are updated regularly
             "registry/web/skill.html",  # Skill detail page format may change
             "llms.txt",  # AI agent installation protocol (emerging standard)
+            ".github/workflows/skill-onboarding.md",  # Agentic workflow instructions updated regularly
         ]
 
         # Infrastructure files - added if missing, or with --force
@@ -1110,7 +1118,6 @@ class SkillService:
             ".github/workflows/release.yml",
             ".github/workflows/sync-registry.yml",
             ".github/workflows/validate-skills.yml",
-            ".github/workflows/auto-rebase.yml",
             # GitHub templates
             ".github/ISSUE_TEMPLATE/new-skill.md",
             ".github/PULL_REQUEST_TEMPLATE.md",
@@ -1251,7 +1258,7 @@ class SkillService:
             ".github/workflows/release.yml": self._write_scaffold_release_workflow,
             ".github/workflows/sync-registry.yml": self._write_scaffold_sync_registry_workflow,
             ".github/workflows/validate-skills.yml": self._write_scaffold_validate_skills_workflow,
-            ".github/workflows/auto-rebase.yml": self._write_scaffold_auto_rebase_workflow,
+            ".github/workflows/skill-onboarding.md": self._write_scaffold_skill_onboarding_workflow,
             # GitHub templates
             ".github/ISSUE_TEMPLATE/new-skill.md": self._write_scaffold_issue_template,
             ".github/PULL_REQUEST_TEMPLATE.md": self._write_scaffold_pr_template,
@@ -1439,6 +1446,45 @@ class SkillService:
         except OSError:
             return False  # Don't fail the upgrade if skills.json can't be written
 
+    def _try_compile_agentic_workflows(self, repo_path: Path) -> bool:
+        """Attempt to compile agentic workflows using gh-aw.
+
+        Looks for .md files in .github/workflows/ and runs `gh aw compile`
+        to generate the corresponding .lock.yml files. These lock files are
+        what GitHub Actions actually executes.
+
+        This is a best-effort operation -- if gh-aw is not installed, the
+        .md file is still scaffolded and the user can compile later.
+
+        Args:
+            repo_path: Path to the repository root
+
+        Returns:
+            True if compilation succeeded, False otherwise
+        """
+        workflows_dir = repo_path / ".github" / "workflows"
+        md_workflows = (
+            list(workflows_dir.glob("*.md")) if workflows_dir.exists() else []
+        )
+
+        if not md_workflows:
+            return False
+
+        try:
+            result = subprocess.run(
+                ["gh", "aw", "compile"],
+                capture_output=True,
+                text=True,
+                cwd=str(repo_path),
+                timeout=60,
+            )
+            return result.returncode == 0
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            # gh-aw extension not installed or timed out -- not an error
+            return False
+        except Exception:
+            return False
+
     def _write_registry_scaffold(self, repo_path: Path, repo_name: str) -> None:
         """Write the full skills registry scaffold with CI/CD automation.
 
@@ -1485,7 +1531,7 @@ class SkillService:
         self._write_scaffold_release_workflow(repo_path)
         self._write_scaffold_sync_registry_workflow(repo_path)
         self._write_scaffold_validate_skills_workflow(repo_path)
-        self._write_scaffold_auto_rebase_workflow(repo_path)
+        self._write_scaffold_skill_onboarding_workflow(repo_path)
 
         # --- Scripts ---
         self._write_scaffold_sync_registry_script(repo_path)
@@ -1775,7 +1821,7 @@ inside Claude Code sessions.
 │       ├── release.yml           # release-please automation
 │       ├── sync-registry.yml     # Rebuilds skills.json post-release
 │       ├── validate-skills.yml   # PR validation checks
-│       └── auto-rebase.yml       # Auto-rebase PRs when shared files change
+│       └── skill-onboarding.md   # Agentic workflow: auto-registers new skills
 ├── scripts/
 │   ├── sync-registry.py          # Parses skills → skills.json
 │   └── validate_skills.py        # Pydantic-based validation
@@ -1835,36 +1881,15 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for how to add or update skills.
    Your skill content here...
    ```
 
-3. **Create version.txt** (bootstrapped at 0.1.0):
-   ```bash
-   echo "0.1.0" > skill/my-skill/version.txt
-   ```
+3. **Open a pull request** — that's it!
 
-4. **Register with release-please** — add to `release-please-config.json`:
-   ```json
-   {{
-     "packages": {{
-       "skill/my-skill": {{
-         "release-type": "simple",
-         "component": "my-skill"
-       }}
-     }}
-   }}
-   ```
+   The **Skill Onboarding** agentic workflow will automatically:
+   - Create `version.txt` with `0.1.0`
+   - Register your skill in `release-please-config.json`
+   - Register your skill in `.release-please-manifest.json`
+   - Push the generated files to your PR branch
 
-   And to `.release-please-manifest.json`:
-   ```json
-   {{
-     "skill/my-skill": "0.1.0"
-   }}
-   ```
-
-5. **Commit and push**:
-   ```bash
-   git add skill/my-skill/ release-please-config.json .release-please-manifest.json
-   git commit -m "feat: add my-skill"
-   git push origin main
-   ```
+4. **Review and merge** your PR once CI passes
 
 ## Updating a Skill
 
@@ -1931,37 +1956,27 @@ tags:
 
 Instructions and content for your skill go here.
 SKILLEOF
-
-# Bootstrap version (required for release-please)
-echo "0.1.0" > skill/my-first-skill/version.txt
 ```
 
-### 2. Register with Release-Please
-
-Add the skill to `release-please-config.json` under `"packages"`:
-
-```json
-"skill/my-first-skill": {{
-  "release-type": "simple",
-  "component": "my-first-skill"
-}}
-```
-
-Add to `.release-please-manifest.json`:
-
-```json
-"skill/my-first-skill": "0.1.0"
-```
-
-### 3. Commit and Push
+### 2. Open a Pull Request
 
 ```bash
-git add .
+git checkout -b add-my-first-skill
+git add skill/my-first-skill/
 git commit -m "feat: add my-first-skill"
-git push origin main
+git push origin add-my-first-skill
+gh pr create --title "feat: add my-first-skill" --body "Adds my-first-skill"
 ```
 
-### 4. What Happens Next
+The **Skill Onboarding** agentic workflow will automatically:
+- Create `version.txt` with `0.1.0`
+- Register your skill in `release-please-config.json`
+- Register your skill in `.release-please-manifest.json`
+- Push the generated files to your PR branch
+
+### 3. Merge and Release
+
+Once CI passes, merge your PR.
 
 1. **release-please** creates a release PR bumping `version.txt`
 2. Merge the release PR → tag `my-first-skill@v0.1.0` is created
@@ -2190,174 +2205,212 @@ jobs:
             content, encoding="utf-8"
         )
 
-    def _write_scaffold_auto_rebase_workflow(self, repo_path: Path) -> None:
-        """Write .github/workflows/auto-rebase.yml for automatic PR rebasing.
+    def _write_scaffold_skill_onboarding_workflow(self, repo_path: Path) -> None:
+        """Write .github/workflows/skill-onboarding.md agentic workflow.
 
-        Automatically rebases PRs when main changes to resolve conflicts
-        with shared files (skills.json, release-please-config.json, etc.)
-        that occur when multiple skills are extracted in parallel.
+        Automatically detects new skills in PRs and generates required
+        release-please configuration, version files, and registry metadata
+        so contributors only need to create their SKILL.md file.
 
-        For JSON files with conflicts, accepts main's version then rebuilds
-        using sync-registry.py to include all skills.
+        This is a GitHub Agentic Workflow (.md format) that requires
+        compilation via `gh aw compile` to generate the .lock.yml file
+        that GitHub Actions actually executes.
+
+        Replaces the previous auto-rebase.yml approach by handling
+        release-please registration on the PR branch before merge,
+        eliminating shared-file merge conflicts.
         """
         content = """\
-name: Auto Rebase
-
+---
+name: Skill Onboarding
+description: >
+  Automatically detects new skills in PRs and generates required
+  release-please configuration and version files so contributors
+  only need to create their SKILL.md file.
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    types: [opened, synchronize]
+    branches: [main]
     paths:
-      - "skills.json"
-      - "release-please-config.json"
-      - ".release-please-manifest.json"
-
+      - "skill/**"
+tools:
+  github:
+  edit:
+  bash: true
+safe-outputs:
+  push-to-pull-request-branch:
+    max: 1
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
+---
 
-jobs:
-  rebase:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+# Skill Onboarding
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
+You are a skill registry automation agent. Your sole job is to detect new
+skills added in pull requests and generate the required configuration files
+so that release-please can version and release them automatically.
 
-      - name: Install dependencies
-        run: pip install python-frontmatter
+## Context
 
-      - name: Rebase open PRs with conflict resolution
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Configure git identity for rebase commits
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+This repository is a ContextHarness skills registry. Skills live in
+`skill/<name>/` directories. Each skill requires these files for the
+release pipeline to work:
 
-          # Get open PRs and process each one
-          gh pr list --base main --state open --json number,headRefName \\
-            --jq '.[] | "\\(.number) \\(.headRefName)"' \\
-            | while read -r pr_number pr_branch; do
-              if [ -z "$pr_number" ] || [ -z "$pr_branch" ]; then
-                continue
-              fi
+1. `skill/<name>/SKILL.md` -- The skill content (created by the contributor)
+2. `skill/<name>/version.txt` -- Contains `0.1.0` (you create this)
+3. An entry in `release-please-config.json` under `packages` (you create this)
+4. An entry in `.release-please-manifest.json` (you create this)
 
-              echo "Attempting to rebase PR #$pr_number ($pr_branch)"
+Contributors only create item 1. You generate items 2-4.
 
-              # Fetch the PR branch
-              git fetch origin "$pr_branch" || continue
+## Instructions
 
-              # Checkout the PR branch
-              git checkout "$pr_branch" || continue
+Follow these steps in exact order. Do NOT skip steps.
 
-              # Try to rebase onto main
-              if git rebase origin/main; then
-                echo "Rebase successful, pushing..."
-                git push origin "$pr_branch" --force-with-lease
-                echo "✅ PR #$pr_number rebased successfully"
-              else
-                echo "⚠️ Rebase has conflicts, attempting auto-resolution..."
+### Step 1: Detect new skills
 
-                # Get list of conflicted files
-                CONFLICTS=$(git diff --name-only --diff-filter=U)
+Use bash to find skill directories that have a `SKILL.md` but are NOT yet
+registered in `release-please-config.json`:
 
-                if echo "$CONFLICTS" | grep -q ".json"; then
-                  echo "Found JSON conflicts: $CONFLICTS"
+```bash
+# List all skill directories containing SKILL.md
+for dir in skill/*/; do
+  if [ -f "${dir}SKILL.md" ]; then
+    skill_name=$(basename "$dir")
+    # Check if already registered in release-please config
+    if ! grep -q "\\"skill/${skill_name}\\"" release-please-config.json 2>/dev/null; then
+      echo "NEW:${skill_name}"
+    fi
+  fi
+done
+```
 
-                  # Resolve each conflicting JSON file by merging
-                  python3 << 'PYRESOLVE'
-import json
-import subprocess
-import os
+If no lines starting with `NEW:` are printed, there are no new skills.
+Stop here and do NOT push any changes.
 
-# Get conflicted files
-result = subprocess.run(['git', 'diff', '--name-only', '--diff-filter=U'],
-                       capture_output=True, text=True)
-conflicts = [f for f in result.stdout.strip().split('\n') if f and f.endswith('.json')]
+### Step 2: Create version.txt for each new skill
 
-for filepath in conflicts:
-    if not os.path.exists(filepath):
-        continue
+For each new skill found in Step 1, use bash to create `version.txt`
+ONLY if it does not already exist:
 
-    # During rebase conflict:
-    # - :2:filepath = stage 2 = "ours" = upstream (main)
-    # - :3:filepath = stage 3 = "theirs" = commit being replayed (PR)
+```bash
+# For each new skill name from Step 1:
+if [ ! -f "skill/<name>/version.txt" ]; then
+  printf "0.1.0" > "skill/<name>/version.txt"
+fi
+```
 
-    # Get main's version (stage 2)
-    main_result = subprocess.run(
-        ['git', 'show', ':2:' + filepath],
-        capture_output=True, text=True
-    )
-    try:
-        main_data = json.loads(main_result.stdout) if main_result.returncode == 0 else {}
-    except:
-        main_data = {}
+The content MUST be exactly the string `0.1.0` with no trailing newline.
+Use `printf` not `echo` to avoid trailing newlines.
 
-    # Get PR's version (stage 3 - the commit being replayed during rebase)
-    ours_result = subprocess.run(
-        ['git', 'show', ':3:' + filepath],
-        capture_output=True, text=True
-    )
-    try:
-        ours_data = json.loads(ours_result.stdout) if ours_result.returncode == 0 else {}
-    except:
-        ours_data = {}
+### Step 3: Update release-please-config.json
 
-    # Deep merge: overlay PR's changes onto main's base
-    def deep_merge(base, overlay):
-        if isinstance(base, dict) and isinstance(overlay, dict):
-            result = dict(base)
-            for k, v in overlay.items():
-                if k in result and isinstance(result[k], dict) and isinstance(v, dict):
-                    result[k] = deep_merge(result[k], v)
-                else:
-                    result[k] = v
-            return result
-        return overlay
+Read `release-please-config.json` with `cat`. For each new skill, add an
+entry to the `packages` object.
 
-    merged = deep_merge(main_data, ours_data)
+The EXACT format for each new entry is:
 
-    # Write merged file
-    with open(filepath, 'w') as f:
-        json.dump(merged, f, indent=2, sort_keys=True)
-        f.write('\n')
+```json
+"skill/<name>": {
+  "release-type": "simple",
+  "component": "<name>"
+}
+```
 
-    print(f"Merged {filepath}")
+Where `<name>` is the directory name (e.g., `my-skill`).
 
-# Also rebuild skills.json from all skills on disk
-subprocess.run(['python', 'scripts/sync-registry.py'], capture_output=True)
-print("Rebuilt skills.json")
-PYRESOLVE
+**Rules you MUST follow:**
 
-                  # Stage all resolved files
-                  git add skills.json release-please-config.json .release-please-manifest.json 2>/dev/null || true
+- NEVER remove or modify ANY existing entries in `packages`
+- NEVER modify top-level keys (`$schema`, `separate-pull-requests`,
+  `include-component-in-tag`, `tag-separator`)
+- Use exactly 2-space indentation
+- Ensure valid JSON with proper commas between all entries
+- Write the file using the `edit` tool
 
-                  # Continue rebase
-                  if git rebase --continue; then
-                    echo "Auto-resolution successful, pushing..."
-                    git push origin "$pr_branch" --force-with-lease
-                    echo "✅ PR #$pr_number rebased with conflict resolution"
-                  else
-                    echo "❌ Could not complete rebase even after conflict resolution"
-                    git rebase --abort
-                  fi
-                else
-                  echo "❌ Non-JSON conflicts detected, cannot auto-resolve"
-                  git rebase --abort
-                fi
-              fi
+**Complete example** -- if the file currently has `example-skill` and
+`skill-release`, and you are adding `my-new-skill`:
 
-              # Go back to main for next iteration
-              git checkout main
-            done
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "separate-pull-requests": true,
+  "include-component-in-tag": true,
+  "tag-separator": "@",
+  "packages": {
+    "skill/example-skill": {
+      "release-type": "simple",
+      "component": "example-skill"
+    },
+    "skill/my-new-skill": {
+      "release-type": "simple",
+      "component": "my-new-skill"
+    },
+    "skill/skill-release": {
+      "release-type": "simple",
+      "component": "skill-release"
+    }
+  }
+}
+```
+
+### Step 4: Update .release-please-manifest.json
+
+Read `.release-please-manifest.json` with `cat`. For each new skill, add
+an entry with the initial version `0.1.0`.
+
+The EXACT format for each new entry is:
+
+```json
+"skill/<name>": "0.1.0"
+```
+
+**Rules you MUST follow:**
+
+- NEVER remove or modify ANY existing entries
+- Use exactly 2-space indentation
+- Ensure valid JSON with proper commas between all entries
+- Write the file using the `edit` tool
+
+**Complete example** -- adding `my-new-skill` to existing entries:
+
+```json
+{
+  "skill/example-skill": "0.1.0",
+  "skill/my-new-skill": "0.1.0",
+  "skill/skill-release": "0.1.0"
+}
+```
+
+### Step 5: Push changes
+
+If you created or modified any files in Steps 2-4, use the
+`push-to-pull-request-branch` safe output to commit and push.
+
+Commit message: `chore: register new skill(s) in release-please`
+
+If no files were created or modified, do NOT push. Produce no output.
+
+## Skip Conditions
+
+Do NOT make any changes and do NOT push if ANY of these are true:
+
+- All skill directories with `SKILL.md` are already in `release-please-config.json`
+- The PR only modifies files in existing skill directories (no new directories)
+- No `SKILL.md` file exists in any new directory under `skill/`
+
+## Quality Checklist
+
+Before pushing, verify:
+
+- [ ] All JSON files are valid (properly nested braces, correct commas)
+- [ ] `version.txt` contains exactly `0.1.0` with no extra whitespace
+- [ ] No existing entries were removed from either JSON file
+- [ ] No `SKILL.md` files were modified
+- [ ] The `component` value matches the directory name exactly
 """
-        (repo_path / ".github" / "workflows" / "auto-rebase.yml").write_text(
+        (repo_path / ".github" / "workflows" / "skill-onboarding.md").write_text(
             content, encoding="utf-8"
         )
 
@@ -2961,37 +3014,25 @@ Your skill content here...
   AND when to use it
 - Do NOT include a `version` field
 
-### Step 3 — Bootstrap version.txt
+### Step 3 — Open a Pull Request
 
 ```bash
-echo "0.1.0" > skill/<skill-name>/version.txt
-```
-
-### Step 4 — Register with release-please
-
-Add to `release-please-config.json` under `"packages"`:
-
-```json
-"skill/<skill-name>": {
-  "release-type": "simple",
-  "component": "<skill-name>"
-}
-```
-
-Add to `.release-please-manifest.json`:
-
-```json
-"skill/<skill-name>": "0.1.0"
-```
-
-### Step 5 — Commit with feat: prefix
-
-```bash
-git add skill/<skill-name>/ release-please-config.json \\
-  .release-please-manifest.json
+git checkout -b add-<skill-name>
+git add skill/<skill-name>/
 git commit -m "feat: add <skill-name>"
-git push origin main
+git push origin add-<skill-name>
+gh pr create --title "feat: add <skill-name>" --body "Adds <skill-name>"
 ```
+
+The **Skill Onboarding** agentic workflow will automatically:
+- Create `version.txt` with `0.1.0`
+- Register the skill in `release-please-config.json`
+- Register the skill in `.release-please-manifest.json`
+- Push the generated files to your PR branch
+
+### Step 4 — Merge
+
+Once CI passes, merge your PR.
 
 The `feat:` prefix is critical — it is a releasable commit type that
 triggers release-please to create the initial release PR.
@@ -3052,7 +3093,6 @@ git commit --allow-empty -m "chore: release 2.0.0" -m "Release-As: 2.0.0"
 |---------|---------|-----|
 | Using `docs:` for skill edits | No release PR created | Use `feat:` or `fix:` |
 | Adding `version` to frontmatter | Validation failure | Remove it |
-| Forgetting release-please registration | No release PR | Add to both JSON files |
 | Editing `version.txt` manually | Version conflict | Revert; let CI manage |
 | Editing `skills.json` manually | Overwritten on release | Let CI rebuild it |
 
@@ -3092,7 +3132,9 @@ pipeline.
    YES → Continue
 
 3. Is the skill registered in release-please-config.json?
-   NO  → Add package entry and re-push
+   NO  → The Skill Onboarding workflow should have added it.
+         Check if the workflow ran on your PR. Re-trigger by
+         pushing a new commit to the PR branch.
    YES → Continue
 
 4. Did the release.yml workflow run?
@@ -4395,14 +4437,42 @@ tags: [category]
         async function discoverFiles() {
             var basePath = 'skill/' + skillName;
             var files = [];
-            var knownFiles = [{ path: 'SKILL.md', icon: '📄', name: 'SKILL.md' }, { path: 'version.txt', icon: '📄', name: 'version.txt' }, { path: 'CHANGELOG.md', icon: '📄', name: 'CHANGELOG.md' }];
-            for (var i = 0; i < knownFiles.length; i++) {
-                var exists = await checkFileExists(basePath + '/' + knownFiles[i].path);
-                if (exists) { files.push(Object.assign({}, knownFiles[i], { type: 'file' })); }
+            try {
+                var res = await fetch(basePath + '/.listing.json');
+                if (res.ok) {
+                    var listing = await res.json();
+                    if (listing.files) {
+                        listing.files.forEach(function(f) {
+                            files.push({ path: f, icon: getIcon(f), name: f, type: 'file' });
+                        });
+                    }
+                    if (listing.directories && listing.directory_files) {
+                        listing.directories.forEach(function(dir) {
+                            var dirFiles = listing.directory_files[dir] || [];
+                            dirFiles.forEach(function(f) {
+                                files.push({ path: dir + '/' + f, icon: getIcon(f), name: dir + '/' + f, type: 'file' });
+                            });
+                        });
+                    }
+                } else {
+                    var knownFiles = ['SKILL.md', 'version.txt', 'CHANGELOG.md'];
+                    for (var i = 0; i < knownFiles.length; i++) {
+                        var exists = await checkFileExists(basePath + '/' + knownFiles[i]);
+                        if (exists) { files.push({ path: knownFiles[i], icon: '📄', name: knownFiles[i], type: 'file' }); }
+                    }
+                }
+            } catch (e) {
+                console.error('Error discovering files:', e);
             }
             renderFileTree(files);
             var skillMd = files.find(function(f) { return f.path === 'SKILL.md'; });
             if (skillMd) { selectFile(skillMd); }
+        }
+        function getIcon(filename) {
+            if (filename.endsWith('.md')) return '📝';
+            if (filename.endsWith('.json')) return '📋';
+            if (filename.endsWith('.txt')) return '📄';
+            return '📄';
         }
         async function checkFileExists(path) {
             try { var res = await fetch(path, { method: 'HEAD' }); return res.ok; }

--- a/src/context_harness/skills.py
+++ b/src/context_harness/skills.py
@@ -112,7 +112,9 @@ def check_gh_auth(quiet: bool = False) -> bool:
                 console.print("[dim]Run 'gh auth login' to authenticate.[/dim]")
             else:
                 console.print("[red]Error: Registry authentication failed.[/red]")
-                console.print("[dim]Check your CONTEXT_HARNESS_REGISTRY_TOKEN environment variable.[/dim]")
+                console.print(
+                    "[dim]Check your CONTEXT_HARNESS_REGISTRY_TOKEN environment variable.[/dim]"
+                )
         return False
     return True
 
@@ -133,9 +135,7 @@ def check_repo_access(repo: Optional[str] = None, quiet: bool = False) -> bool:
         if not quiet:
             registry_url = get_current_skills_repo()
             console.print(f"[red]Error: Cannot access registry '{registry_url}'[/red]")
-            console.print(
-                "[dim]Make sure you have access to the registry.[/dim]"
-            )
+            console.print("[dim]Make sure you have access to the registry.[/dim]")
         return False
     return True
 
@@ -272,9 +272,7 @@ def get_skill_info(skill_name: str, quiet: bool = False) -> Optional[SkillInfo]:
     return None
 
 
-def _fetch_directory_recursive(
-    path: str, dest: Path, quiet: bool = False
-) -> bool:
+def _fetch_directory_recursive(path: str, dest: Path, quiet: bool = False) -> bool:
     """Recursively fetch a directory from the registry.
 
     Supports both GitHub and HTTP registries.
@@ -460,14 +458,20 @@ def init_repo(
         if not quiet:
             console.print(f"\n[green]✅ {result.message}[/green]")
             console.print(f"[dim]URL: {repo.url}[/dim]")
+            console.print("\n[yellow]⚠️  Next steps:[/yellow]")
+            console.print("[yellow]1. Configure GitHub Actions permissions[/yellow]")
             console.print(
-                "\n[yellow]⚠️  Next: Configure GitHub Actions permissions[/yellow]"
+                "[dim]   Settings → Actions → General → Workflow permissions[/dim]"
             )
             console.print(
-                "[dim]Settings → Actions → General → Workflow permissions[/dim]"
+                "[dim]   Select 'Read and write' + 'Allow Actions to create PRs'[/dim]"
             )
             console.print(
-                "[dim]Select 'Read and write' + 'Allow Actions to create PRs'[/dim]"
+                "[yellow]2. Set up Agentic Workflows (for automated skill onboarding)[/yellow]"
+            )
+            console.print("[dim]   Install: gh extension install github/gh-aw[/dim]")
+            console.print(
+                "[dim]   Compile: gh aw compile (in the repo directory)[/dim]"
             )
         return SkillResult.SUCCESS, repo.url
 
@@ -534,23 +538,31 @@ def upgrade_repo(
 
         if not quiet:
             if data.get("upgraded"):
-                console.print(f"\n[green]✅ Registry upgraded: {current} → {latest}[/green]")
+                console.print(
+                    f"\n[green]✅ Registry upgraded: {current} → {latest}[/green]"
+                )
                 updated = data.get("files_updated", [])
                 if updated:
                     console.print("[dim]Updated files:[/dim]")
                     for f in updated:
                         console.print(f"[dim]  - {f}[/dim]")
             elif data.get("dry_run"):
-                console.print(f"\n[yellow]Dry run: would upgrade {current} → {latest}[/yellow]")
+                console.print(
+                    f"\n[yellow]Dry run: would upgrade {current} → {latest}[/yellow]"
+                )
                 to_update = data.get("files_to_update", [])
                 if to_update:
                     console.print("[dim]Files to update:[/dim]")
                     for f in to_update:
                         console.print(f"[dim]  - {f}[/dim]")
             elif data.get("upgrade_available"):
-                console.print(f"\n[yellow]Upgrade available: {current} → {latest}[/yellow]")
+                console.print(
+                    f"\n[yellow]Upgrade available: {current} → {latest}[/yellow]"
+                )
             else:
-                console.print(f"\n[green]✅ Registry is up to date (version {current})[/green]")
+                console.print(
+                    f"\n[green]✅ Registry is up to date (version {current})[/green]"
+                )
 
         return SkillResult.SUCCESS, data
 
@@ -794,13 +806,17 @@ def extract_skill(
                 initial_version = frontmatter.get("version", "0.1.0")
                 version_file.write_text(initial_version + "\n", encoding="utf-8")
                 if not quiet:
-                    console.print(f"[dim]Created version.txt with {initial_version}[/dim]")
+                    console.print(
+                        f"[dim]Created version.txt with {initial_version}[/dim]"
+                    )
 
             # Generate .listing.json for frontend file discovery
             _generate_skill_listing(skill_dest)
 
             # Update release-please config to register the new skill
-            _update_release_please_config(tmppath, skill_name, frontmatter.get("version", "0.1.0"))
+            _update_release_please_config(
+                tmppath, skill_name, frontmatter.get("version", "0.1.0")
+            )
 
             # Update or create skills.json registry
             registry_path = tmppath / SKILLS_REGISTRY_PATH
@@ -1142,7 +1158,9 @@ def _generate_skill_listing(skill_path: Path) -> None:
     listing_path.write_text(json.dumps(listing, indent=2) + "\n", encoding="utf-8")
 
 
-def _update_release_please_config(repo_path: Path, skill_name: str, version: str) -> None:
+def _update_release_please_config(
+    repo_path: Path, skill_name: str, version: str
+) -> None:
     """Update release-please config files to register a new skill.
 
     Args:
@@ -1193,7 +1211,9 @@ def _update_release_please_config(repo_path: Path, skill_name: str, version: str
     # Add the skill version if not already present
     if skill_path not in manifest:
         manifest[skill_path] = version
-        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+        )
 
 
 def _get_github_username() -> str:

--- a/src/context_harness/storage/file_storage.py
+++ b/src/context_harness/storage/file_storage.py
@@ -152,7 +152,8 @@ class FileStorage:
             return True
         except FileNotFoundError:
             return False
-        except IsADirectoryError:
+        except (IsADirectoryError, PermissionError):
+            # IsADirectoryError on Linux, PermissionError on macOS
             return False
 
     def exists(self, path: PathLike) -> bool:

--- a/src/context_harness/templates/.opencode/skill/skill-release/SKILL.md
+++ b/src/context_harness/templates/.opencode/skill/skill-release/SKILL.md
@@ -50,36 +50,25 @@ Your skill content here...
 - `description` is required and should explain both what the skill does AND when to use it
 - Do NOT include a `version` field
 
-### Step 3 - Bootstrap version.txt
+### Step 3 - Open a Pull Request
 
 ```bash
-echo "0.1.0" > skill/<skill-name>/version.txt
-```
-
-### Step 4 - Register with release-please
-
-Add to `release-please-config.json` under `"packages"`:
-
-```json
-"skill/<skill-name>": {
-  "release-type": "simple",
-  "component": "<skill-name>"
-}
-```
-
-Add to `.release-please-manifest.json`:
-
-```json
-"skill/<skill-name>": "0.1.0"
-```
-
-### Step 5 - Commit with feat: prefix
-
-```bash
-git add skill/<skill-name>/ release-please-config.json .release-please-manifest.json
+git checkout -b add-<skill-name>
+git add skill/<skill-name>/
 git commit -m "feat: add <skill-name>"
-git push origin main
+git push origin add-<skill-name>
+gh pr create --title "feat: add <skill-name>" --body "Adds <skill-name>"
 ```
+
+The **Skill Onboarding** agentic workflow will automatically:
+- Create `version.txt` with `0.1.0`
+- Register the skill in `release-please-config.json`
+- Register the skill in `.release-please-manifest.json`
+- Push the generated files to your PR branch
+
+### Step 4 - Merge
+
+Once CI passes, merge your PR.
 
 The `feat:` prefix is critical - it is a releasable commit type that triggers release-please to create the initial release PR.
 
@@ -141,11 +130,9 @@ git commit --allow-empty -m "chore: release 2.0.0" -m "Release-As: 2.0.0"
 |---------|---------|-----|
 | Using `docs:` for skill edits | No release PR created | Use `feat:` or `fix:` for any SKILL.md change |
 | Adding `version` to frontmatter | Validation failure on PR | Remove it; version lives in `version.txt` only |
-| Forgetting release-please registration | No release PR for new skill | Add to both config and manifest JSON files |
 | Editing `version.txt` manually | Version conflict with release-please | Revert; let release-please manage it |
 | Editing `skills.json` manually | Overwritten on next release | Let sync-registry.yml rebuild it |
 | `name` != directory name | Validation failure | Ensure frontmatter `name` matches exactly |
-| Missing `version.txt` for new skill | release-please cannot bootstrap | Create with `echo "0.1.0" > skill/<name>/version.txt` |
 
 ## Multi-Skill Commits
 
@@ -169,8 +156,8 @@ These files in the registry repo are relevant to the release process:
 | `skill/<name>/SKILL.md` | Author | Skill content (no version field) |
 | `skill/<name>/version.txt` | release-please | Current version (CI-managed) |
 | `skill/<name>/CHANGELOG.md` | release-please | Generated changelog |
-| `release-please-config.json` | Author (add only) | Per-skill release config |
-| `.release-please-manifest.json` | release-please | Current versions (CI-managed after bootstrap) |
+| `release-please-config.json` | Skill Onboarding workflow | Per-skill release config (auto-registered) |
+| `.release-please-manifest.json` | release-please | Current versions (auto-bootstrapped) |
 | `skills.json` | CI | Auto-rebuilt registry manifest |
 | `CONTRIBUTING.md` | Reference | Full authoring guidelines |
 | `QUICKSTART.md` | Reference | First-skill tutorial |

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -25,43 +25,35 @@ from context_harness.completion import (
 class TestFuzzyMatch:
     """Tests for fuzzy matching algorithm."""
 
-    def test_fuzzy_match_exact(self):
-        """Test exact match."""
-        assert _fuzzy_match("react-forms", "react-forms") is True
-
-    def test_fuzzy_match_prefix(self):
-        """Test prefix match."""
-        assert _fuzzy_match("react", "react-forms") is True
-
-    def test_fuzzy_match_fuzzy(self):
-        """Test fuzzy pattern matching."""
-        assert _fuzzy_match("rf", "react-forms") is True
-        assert _fuzzy_match("dja", "django-auth") is True
-        assert _fuzzy_match("rfs", "react-forms") is True
-
-    def test_fuzzy_match_case_insensitive(self):
-        """Test case insensitive matching."""
-        assert _fuzzy_match("RF", "react-forms") is True
-        assert _fuzzy_match("react", "React-Forms") is True
-
-    def test_fuzzy_match_no_match(self):
-        """Test non-matching patterns."""
-        assert _fuzzy_match("xyz", "react-forms") is False
-        assert _fuzzy_match("abc", "django-auth") is False
-
-    def test_fuzzy_match_empty_pattern(self):
-        """Test empty pattern matches everything."""
-        assert _fuzzy_match("", "react-forms") is True
-        assert _fuzzy_match("", "anything") is True
-
-    def test_fuzzy_match_pattern_longer_than_text(self):
-        """Test pattern longer than text doesn't match."""
-        assert _fuzzy_match("react-forms-extended", "react") is False
-
-    def test_fuzzy_match_special_characters(self):
-        """Test matching with hyphens and underscores."""
-        assert _fuzzy_match("r-f", "react-forms") is True
-        assert _fuzzy_match("r_f", "react_forms") is True
+    @pytest.mark.parametrize(
+        "pattern,text,expected",
+        [
+            # Exact match
+            ("react-forms", "react-forms", True),
+            # Prefix match
+            ("react", "react-forms", True),
+            # Fuzzy pattern matching
+            ("rf", "react-forms", True),
+            ("dja", "django-auth", True),
+            ("rfs", "react-forms", True),
+            # Case insensitive
+            ("RF", "react-forms", True),
+            ("react", "React-Forms", True),
+            # No match
+            ("xyz", "react-forms", False),
+            ("abc", "django-auth", False),
+            # Empty pattern matches everything
+            ("", "react-forms", True),
+            ("", "anything", True),
+            # Pattern longer than text doesn't match
+            ("react-forms-extended", "react", False),
+            # Special characters
+            ("r-f", "react-forms", True),
+            ("r_f", "react_forms", True),
+        ],
+    )
+    def test_fuzzy_match(self, pattern, text, expected):
+        assert _fuzzy_match(pattern, text) is expected
 
 
 class TestFuzzyScore:
@@ -148,14 +140,12 @@ class TestCaching:
         """Test that expired cache returns None."""
         cache_dir, cache_file = clean_cache
 
-        # Set a very short TTL for testing
-        monkeypatch.setattr("context_harness.completion.CACHE_TTL_SECONDS", 1)
-
         skills = [{"name": "skill-one", "description": "First"}]
         _save_skills_to_cache(skills)
 
-        # Wait for cache to expire
-        time.sleep(1.5)
+        # Advance time past the TTL so the cached timestamp appears expired
+        future_time = time.time() + CACHE_TTL_SECONDS + 10
+        monkeypatch.setattr(time, "time", lambda: future_time)
 
         result = _get_cached_skills()
         assert result is None

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -4,7 +4,6 @@ import base64
 import hashlib
 import json
 import os
-import tempfile
 import threading
 import time
 from pathlib import Path
@@ -41,6 +40,16 @@ from context_harness.oauth import (
     check_mcp_auth_required,
     get_mcp_bearer_token,
 )
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    """Redirect Path.home() to a temp directory for isolated token storage.
+
+    Yields the tmp_path so tests can inspect the filesystem if needed.
+    """
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    return tmp_path
 
 
 class TestGeneratePKCE:
@@ -237,94 +246,76 @@ class TestAtlassianResource:
 class TestTokenStorage:
     """Tests for TokenStorage class."""
 
-    def test_storage_uses_file_fallback(self):
+    def test_storage_uses_file_fallback(self, fake_home):
         """Test that storage falls back to file when keyring unavailable."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch.object(Path, "home", return_value=Path(tmpdir)):
-                storage = TokenStorage(use_keyring=False)
+        storage = TokenStorage(use_keyring=False)
 
-                tokens = OAuthTokens(access_token="test_token", expires_in=3600)
-                storage.save_tokens("atlassian", tokens)
+        tokens = OAuthTokens(access_token="test_token", expires_in=3600)
+        storage.save_tokens("atlassian", tokens)
 
-                loaded = storage.load_tokens("atlassian")
-                assert loaded is not None
-                assert loaded.access_token == "test_token"
+        loaded = storage.load_tokens("atlassian")
+        assert loaded is not None
+        assert loaded.access_token == "test_token"
 
-    def test_storage_delete_tokens(self):
+    def test_storage_delete_tokens(self, fake_home):
         """Test that tokens can be deleted."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch.object(Path, "home", return_value=Path(tmpdir)):
-                storage = TokenStorage(use_keyring=False)
+        storage = TokenStorage(use_keyring=False)
 
-                tokens = OAuthTokens(access_token="test_token")
-                storage.save_tokens("atlassian", tokens)
+        tokens = OAuthTokens(access_token="test_token")
+        storage.save_tokens("atlassian", tokens)
 
-                assert storage.delete_tokens("atlassian")
-                assert storage.load_tokens("atlassian") is None
+        assert storage.delete_tokens("atlassian")
+        assert storage.load_tokens("atlassian") is None
 
-    def test_storage_delete_nonexistent_returns_false(self):
+    def test_storage_delete_nonexistent_returns_false(self, fake_home):
         """Test that deleting nonexistent tokens returns False."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch.object(Path, "home", return_value=Path(tmpdir)):
-                storage = TokenStorage(use_keyring=False)
-                assert not storage.delete_tokens("nonexistent")
+        storage = TokenStorage(use_keyring=False)
+        assert not storage.delete_tokens("nonexistent")
 
-    def test_storage_auth_status_not_authenticated(self):
+    def test_storage_auth_status_not_authenticated(self, fake_home):
         """Test auth status when no tokens stored."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch.object(Path, "home", return_value=Path(tmpdir)):
-                storage = TokenStorage(use_keyring=False)
-                assert (
-                    storage.get_auth_status("atlassian") == AuthStatus.NOT_AUTHENTICATED
-                )
+        storage = TokenStorage(use_keyring=False)
+        assert storage.get_auth_status("atlassian") == AuthStatus.NOT_AUTHENTICATED
 
-    def test_storage_auth_status_authenticated(self):
+    def test_storage_auth_status_authenticated(self, fake_home):
         """Test auth status when valid tokens stored."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch.object(Path, "home", return_value=Path(tmpdir)):
-                storage = TokenStorage(use_keyring=False)
-                tokens = OAuthTokens(access_token="test", expires_in=3600)
-                storage.save_tokens("atlassian", tokens)
+        storage = TokenStorage(use_keyring=False)
+        tokens = OAuthTokens(access_token="test", expires_in=3600)
+        storage.save_tokens("atlassian", tokens)
 
-                assert storage.get_auth_status("atlassian") == AuthStatus.AUTHENTICATED
+        assert storage.get_auth_status("atlassian") == AuthStatus.AUTHENTICATED
 
-    def test_storage_auth_status_expired(self):
+    def test_storage_auth_status_expired(self, fake_home):
         """Test auth status when tokens expired."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch.object(Path, "home", return_value=Path(tmpdir)):
-                storage = TokenStorage(use_keyring=False)
-                tokens = OAuthTokens(
-                    access_token="test",
-                    expires_in=3600,
-                    issued_at=time.time() - 4000,
-                )
-                storage.save_tokens("atlassian", tokens)
+        storage = TokenStorage(use_keyring=False)
+        tokens = OAuthTokens(
+            access_token="test",
+            expires_in=3600,
+            issued_at=time.time() - 4000,
+        )
+        storage.save_tokens("atlassian", tokens)
 
-                assert storage.get_auth_status("atlassian") == AuthStatus.TOKEN_EXPIRED
+        assert storage.get_auth_status("atlassian") == AuthStatus.TOKEN_EXPIRED
 
-    def test_storage_creates_token_directory(self):
+    def test_storage_creates_token_directory(self, fake_home):
         """Test that storage creates the token directory."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch.object(Path, "home", return_value=Path(tmpdir)):
-                storage = TokenStorage(use_keyring=False)
-                tokens = OAuthTokens(access_token="test")
-                storage.save_tokens("atlassian", tokens)
+        storage = TokenStorage(use_keyring=False)
+        tokens = OAuthTokens(access_token="test")
+        storage.save_tokens("atlassian", tokens)
 
-                token_dir = Path(tmpdir) / ".context-harness/tokens"
-                assert token_dir.exists()
+        token_dir = fake_home / ".context-harness/tokens"
+        assert token_dir.exists()
 
-    def test_storage_load_invalid_json_returns_none(self):
+    def test_storage_load_invalid_json_returns_none(self, fake_home):
         """Test that loading invalid JSON returns None."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch.object(Path, "home", return_value=Path(tmpdir)):
-                storage = TokenStorage(use_keyring=False)
+        storage = TokenStorage(use_keyring=False)
 
-                # Create invalid token file
-                token_dir = Path(tmpdir) / ".context-harness/tokens"
-                token_dir.mkdir(parents=True)
-                (token_dir / "atlassian.json").write_text("invalid json")
+        # Create invalid token file
+        token_dir = fake_home / ".context-harness/tokens"
+        token_dir.mkdir(parents=True)
+        (token_dir / "atlassian.json").write_text("invalid json")
 
-                assert storage.load_tokens("atlassian") is None
+        assert storage.load_tokens("atlassian") is None
 
 
 class TestOAuthCallbackHandler:
@@ -432,29 +423,25 @@ class TestAtlassianOAuthFlow:
         assert "state=" in url
         assert "audience=api.atlassian.com" in url
 
-    def test_flow_get_auth_status(self):
+    def test_flow_get_auth_status(self, fake_home):
         """Test flow auth status check."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch.object(Path, "home", return_value=Path(tmpdir)):
-                config = AtlassianOAuthConfig(client_id="test")
-                storage = TokenStorage(use_keyring=False)
-                flow = AtlassianOAuthFlow(config, token_storage=storage)
+        config = AtlassianOAuthConfig(client_id="test")
+        storage = TokenStorage(use_keyring=False)
+        flow = AtlassianOAuthFlow(config, token_storage=storage)
 
-                assert flow.get_auth_status() == AuthStatus.NOT_AUTHENTICATED
+        assert flow.get_auth_status() == AuthStatus.NOT_AUTHENTICATED
 
-    def test_flow_logout(self):
+    def test_flow_logout(self, fake_home):
         """Test flow logout."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch.object(Path, "home", return_value=Path(tmpdir)):
-                config = AtlassianOAuthConfig(client_id="test")
-                storage = TokenStorage(use_keyring=False)
-                flow = AtlassianOAuthFlow(config, token_storage=storage)
+        config = AtlassianOAuthConfig(client_id="test")
+        storage = TokenStorage(use_keyring=False)
+        flow = AtlassianOAuthFlow(config, token_storage=storage)
 
-                # Save some tokens first
-                storage.save_tokens("atlassian", OAuthTokens(access_token="test"))
+        # Save some tokens first
+        storage.save_tokens("atlassian", OAuthTokens(access_token="test"))
 
-                assert flow.logout()  # Should succeed
-                assert not flow.logout()  # Should fail - already logged out
+        assert flow.logout()  # Should succeed
+        assert not flow.logout()  # Should fail - already logged out
 
 
 class TestGetAtlassianOAuthFlow:
@@ -567,38 +554,32 @@ class TestMCPOAuthDiscovery:
 class TestGetMCPBearerToken:
     """Tests for get_mcp_bearer_token function."""
 
-    def test_returns_none_when_not_authenticated(self):
+    def test_returns_none_when_not_authenticated(self, fake_home):
         """Test returns None when no tokens stored."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch.object(Path, "home", return_value=Path(tmpdir)):
-                result = get_mcp_bearer_token("atlassian")
-                assert result is None
+        result = get_mcp_bearer_token("atlassian")
+        assert result is None
 
-    def test_returns_token_when_authenticated(self):
+    def test_returns_token_when_authenticated(self, fake_home):
         """Test returns token when valid tokens stored."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch.object(Path, "home", return_value=Path(tmpdir)):
-                storage = TokenStorage(use_keyring=False)
-                tokens = OAuthTokens(access_token="test_token", expires_in=3600)
-                storage.save_tokens("atlassian", tokens)
+        storage = TokenStorage(use_keyring=False)
+        tokens = OAuthTokens(access_token="test_token", expires_in=3600)
+        storage.save_tokens("atlassian", tokens)
 
-                result = get_mcp_bearer_token("atlassian")
-                assert result == "test_token"
+        result = get_mcp_bearer_token("atlassian")
+        assert result == "test_token"
 
-    def test_returns_none_when_token_expired(self):
+    def test_returns_none_when_token_expired(self, fake_home):
         """Test returns None when tokens expired."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch.object(Path, "home", return_value=Path(tmpdir)):
-                storage = TokenStorage(use_keyring=False)
-                tokens = OAuthTokens(
-                    access_token="test_token",
-                    expires_in=3600,
-                    issued_at=time.time() - 4000,  # Expired
-                )
-                storage.save_tokens("atlassian", tokens)
+        storage = TokenStorage(use_keyring=False)
+        tokens = OAuthTokens(
+            access_token="test_token",
+            expires_in=3600,
+            issued_at=time.time() - 4000,  # Expired
+        )
+        storage.save_tokens("atlassian", tokens)
 
-                result = get_mcp_bearer_token("atlassian")
-                assert result is None
+        result = get_mcp_bearer_token("atlassian")
+        assert result is None
 
 
 class TestMCPAuthCLI:
@@ -843,54 +824,48 @@ class TestMCPOAuthFlow:
         assert "prompt=consent" in url
         assert "custom=value" in url
 
-    def test_flow_get_auth_status(self):
+    def test_flow_get_auth_status(self, fake_home):
         """Test flow auth status check."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch.object(Path, "home", return_value=Path(tmpdir)):
-                config = OAuthConfig(
-                    service_name="test-service",
-                    client_id="test_client",
-                    auth_url="https://auth.example.com/authorize",
-                    token_url="https://auth.example.com/token",
-                )
-                storage = TokenStorage(use_keyring=False)
-                flow = MCPOAuthFlow(config, token_storage=storage)
+        config = OAuthConfig(
+            service_name="test-service",
+            client_id="test_client",
+            auth_url="https://auth.example.com/authorize",
+            token_url="https://auth.example.com/token",
+        )
+        storage = TokenStorage(use_keyring=False)
+        flow = MCPOAuthFlow(config, token_storage=storage)
 
-                assert flow.get_auth_status() == AuthStatus.NOT_AUTHENTICATED
+        assert flow.get_auth_status() == AuthStatus.NOT_AUTHENTICATED
 
-    def test_flow_get_tokens_returns_none_when_not_authenticated(self):
+    def test_flow_get_tokens_returns_none_when_not_authenticated(self, fake_home):
         """Test that get_tokens returns None when not authenticated."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch.object(Path, "home", return_value=Path(tmpdir)):
-                config = OAuthConfig(
-                    service_name="test-service",
-                    client_id="test_client",
-                    auth_url="https://auth.example.com/authorize",
-                    token_url="https://auth.example.com/token",
-                )
-                storage = TokenStorage(use_keyring=False)
-                flow = MCPOAuthFlow(config, token_storage=storage)
+        config = OAuthConfig(
+            service_name="test-service",
+            client_id="test_client",
+            auth_url="https://auth.example.com/authorize",
+            token_url="https://auth.example.com/token",
+        )
+        storage = TokenStorage(use_keyring=False)
+        flow = MCPOAuthFlow(config, token_storage=storage)
 
-                assert flow.get_tokens() is None
+        assert flow.get_tokens() is None
 
-    def test_flow_logout(self):
+    def test_flow_logout(self, fake_home):
         """Test flow logout."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch.object(Path, "home", return_value=Path(tmpdir)):
-                config = OAuthConfig(
-                    service_name="test-service",
-                    client_id="test_client",
-                    auth_url="https://auth.example.com/authorize",
-                    token_url="https://auth.example.com/token",
-                )
-                storage = TokenStorage(use_keyring=False)
-                flow = MCPOAuthFlow(config, token_storage=storage)
+        config = OAuthConfig(
+            service_name="test-service",
+            client_id="test_client",
+            auth_url="https://auth.example.com/authorize",
+            token_url="https://auth.example.com/token",
+        )
+        storage = TokenStorage(use_keyring=False)
+        flow = MCPOAuthFlow(config, token_storage=storage)
 
-                # Save some tokens first
-                storage.save_tokens("test-service", OAuthTokens(access_token="test"))
+        # Save some tokens first
+        storage.save_tokens("test-service", OAuthTokens(access_token="test"))
 
-                assert flow.logout()  # Should succeed
-                assert not flow.logout()  # Should fail - already logged out
+        assert flow.logout()  # Should succeed
+        assert not flow.logout()  # Should fail - already logged out
 
 
 class TestGetOAuthFlow:
@@ -959,58 +934,48 @@ class TestAtlassianOAuthConfigToGeneric:
 class TestTokenStorageMultipleServices:
     """Tests for TokenStorage with multiple services."""
 
-    def test_storage_isolates_services(self):
+    def test_storage_isolates_services(self, fake_home):
         """Test that tokens are isolated per service."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch.object(Path, "home", return_value=Path(tmpdir)):
-                storage = TokenStorage(use_keyring=False)
+        storage = TokenStorage(use_keyring=False)
 
-                # Store tokens for different services
-                storage.save_tokens(
-                    "atlassian", OAuthTokens(access_token="atlassian_token")
-                )
-                storage.save_tokens("github", OAuthTokens(access_token="github_token"))
+        # Store tokens for different services
+        storage.save_tokens("atlassian", OAuthTokens(access_token="atlassian_token"))
+        storage.save_tokens("github", OAuthTokens(access_token="github_token"))
 
-                # Verify isolation
-                atlassian = storage.load_tokens("atlassian")
-                github = storage.load_tokens("github")
+        # Verify isolation
+        atlassian = storage.load_tokens("atlassian")
+        github = storage.load_tokens("github")
 
-                assert atlassian is not None
-                assert atlassian.access_token == "atlassian_token"
-                assert github is not None
-                assert github.access_token == "github_token"
+        assert atlassian is not None
+        assert atlassian.access_token == "atlassian_token"
+        assert github is not None
+        assert github.access_token == "github_token"
 
-    def test_deleting_one_service_doesnt_affect_others(self):
+    def test_deleting_one_service_doesnt_affect_others(self, fake_home):
         """Test that deleting tokens for one service doesn't affect others."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch.object(Path, "home", return_value=Path(tmpdir)):
-                storage = TokenStorage(use_keyring=False)
+        storage = TokenStorage(use_keyring=False)
 
-                storage.save_tokens(
-                    "atlassian", OAuthTokens(access_token="atlassian_token")
-                )
-                storage.save_tokens("github", OAuthTokens(access_token="github_token"))
+        storage.save_tokens("atlassian", OAuthTokens(access_token="atlassian_token"))
+        storage.save_tokens("github", OAuthTokens(access_token="github_token"))
 
-                # Delete one service
-                storage.delete_tokens("atlassian")
+        # Delete one service
+        storage.delete_tokens("atlassian")
 
-                # Verify other service is unaffected
-                assert storage.load_tokens("atlassian") is None
-                github = storage.load_tokens("github")
-                assert github is not None
-                assert github.access_token == "github_token"
+        # Verify other service is unaffected
+        assert storage.load_tokens("atlassian") is None
+        github = storage.load_tokens("github")
+        assert github is not None
+        assert github.access_token == "github_token"
 
 
 class TestGetMCPBearerTokenGeneric:
     """Tests for get_mcp_bearer_token with multiple services."""
 
-    def test_returns_token_for_any_service(self):
+    def test_returns_token_for_any_service(self, fake_home):
         """Test returns token for any registered service."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with mock.patch.object(Path, "home", return_value=Path(tmpdir)):
-                storage = TokenStorage(use_keyring=False)
-                tokens = OAuthTokens(access_token="custom_token", expires_in=3600)
-                storage.save_tokens("custom-service", tokens)
+        storage = TokenStorage(use_keyring=False)
+        tokens = OAuthTokens(access_token="custom_token", expires_in=3600)
+        storage.save_tokens("custom-service", tokens)
 
-                result = get_mcp_bearer_token("custom-service")
-                assert result == "custom_token"
+        result = get_mcp_bearer_token("custom-service")
+        assert result == "custom_token"

--- a/tests/unit/interfaces/cli/test_worktree_cmd.py
+++ b/tests/unit/interfaces/cli/test_worktree_cmd.py
@@ -1,0 +1,415 @@
+"""Integration tests for worktree CLI commands.
+
+Tests the 5 worktree CLI commands (list, current, add, remove, prune) using
+Click's CliRunner with mocked WorktreeService to avoid git dependencies.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from context_harness.primitives import (
+    ErrorCode,
+    Failure,
+    Success,
+    WorktreeInfo,
+    WorktreeList,
+)
+from context_harness.interfaces.cli.worktree_cmd import (
+    worktree_group,
+)
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _make_worktree(
+    path: str = "/project",
+    head: str = "abc123",
+    branch: str = "refs/heads/main",
+    is_main: bool = True,
+    is_detached: bool = False,
+) -> WorktreeInfo:
+    """Helper to create a WorktreeInfo for tests."""
+    return WorktreeInfo(
+        path=Path(path),
+        head=head,
+        branch=branch if not is_detached else None,
+        is_main=is_main,
+        is_bare=False,
+        is_detached=is_detached,
+    )
+
+
+# ---------------------------------------------------------------------------
+# worktree list
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreeListCmd:
+    """Tests for `worktree list` command."""
+
+    def test_list_shows_worktrees(self, runner):
+        mock_service = MagicMock()
+        mock_service.list_all.return_value = Success(
+            WorktreeList(
+                worktrees=[
+                    _make_worktree("/project", branch="refs/heads/main", is_main=True),
+                    _make_worktree(
+                        "/project-feature",
+                        head="def456",
+                        branch="refs/heads/feature",
+                        is_main=False,
+                    ),
+                ],
+                git_common_dir=Path("/project/.git"),
+            )
+        )
+
+        with patch(
+            "context_harness.interfaces.cli.worktree_cmd.WorktreeService",
+            return_value=mock_service,
+        ):
+            result = runner.invoke(worktree_group, ["list"])
+
+        assert result.exit_code == 0
+        assert "main" in result.output
+        assert "feature" in result.output
+        assert "2 worktree(s)" in result.output
+
+    def test_list_empty(self, runner):
+        mock_service = MagicMock()
+        mock_service.list_all.return_value = Success(
+            WorktreeList(worktrees=[], git_common_dir=Path("/project/.git"))
+        )
+
+        with patch(
+            "context_harness.interfaces.cli.worktree_cmd.WorktreeService",
+            return_value=mock_service,
+        ):
+            result = runner.invoke(worktree_group, ["list"])
+
+        assert result.exit_code == 0
+        assert "No worktrees found" in result.output
+
+    def test_list_failure(self, runner):
+        mock_service = MagicMock()
+        mock_service.list_all.return_value = Failure(
+            error="Not a git repository", code=ErrorCode.NOT_A_GIT_REPO
+        )
+
+        with patch(
+            "context_harness.interfaces.cli.worktree_cmd.WorktreeService",
+            return_value=mock_service,
+        ):
+            result = runner.invoke(worktree_group, ["list"])
+
+        assert result.exit_code == 1
+
+    def test_list_detached_head(self, runner):
+        mock_service = MagicMock()
+        mock_service.list_all.return_value = Success(
+            WorktreeList(
+                worktrees=[
+                    _make_worktree(
+                        "/project", head="abc1234", is_main=True, is_detached=True
+                    ),
+                ],
+                git_common_dir=Path("/project/.git"),
+            )
+        )
+
+        with patch(
+            "context_harness.interfaces.cli.worktree_cmd.WorktreeService",
+            return_value=mock_service,
+        ):
+            result = runner.invoke(worktree_group, ["list"])
+
+        assert result.exit_code == 0
+        assert "detached" in result.output
+
+
+# ---------------------------------------------------------------------------
+# worktree current
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreeCurrentCmd:
+    """Tests for `worktree current` command."""
+
+    def test_current_main_worktree(self, runner):
+        mock_service = MagicMock()
+        mock_service.get_current.return_value = Success(
+            _make_worktree("/project", branch="refs/heads/main", is_main=True)
+        )
+
+        with patch(
+            "context_harness.interfaces.cli.worktree_cmd.WorktreeService",
+            return_value=mock_service,
+        ):
+            result = runner.invoke(worktree_group, ["current"])
+
+        assert result.exit_code == 0
+        assert "Main worktree" in result.output
+        assert "main" in result.output
+
+    def test_current_linked_worktree(self, runner):
+        mock_service = MagicMock()
+        mock_service.get_current.return_value = Success(
+            _make_worktree(
+                "/project-feature",
+                branch="refs/heads/feature",
+                is_main=False,
+            )
+        )
+
+        with patch(
+            "context_harness.interfaces.cli.worktree_cmd.WorktreeService",
+            return_value=mock_service,
+        ):
+            result = runner.invoke(worktree_group, ["current"])
+
+        assert result.exit_code == 0
+        assert "Linked worktree" in result.output
+
+    def test_current_detached(self, runner):
+        mock_service = MagicMock()
+        mock_service.get_current.return_value = Success(
+            _make_worktree("/project", head="abc1234567890", is_detached=True)
+        )
+
+        with patch(
+            "context_harness.interfaces.cli.worktree_cmd.WorktreeService",
+            return_value=mock_service,
+        ):
+            result = runner.invoke(worktree_group, ["current"])
+
+        assert result.exit_code == 0
+        assert "detached" in result.output
+
+    def test_current_failure(self, runner):
+        mock_service = MagicMock()
+        mock_service.get_current.return_value = Failure(
+            error="Not a git repository", code=ErrorCode.NOT_A_GIT_REPO
+        )
+
+        with patch(
+            "context_harness.interfaces.cli.worktree_cmd.WorktreeService",
+            return_value=mock_service,
+        ):
+            result = runner.invoke(worktree_group, ["current"])
+
+        assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# worktree add
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreeAddCmd:
+    """Tests for `worktree add` command."""
+
+    def test_add_with_existing_branch(self, runner, tmp_path):
+        mock_service = MagicMock()
+        wt = _make_worktree(
+            str(tmp_path / "feature"),
+            branch="refs/heads/feature",
+            is_main=False,
+        )
+        mock_service.create.return_value = Success(wt)
+
+        with patch(
+            "context_harness.interfaces.cli.worktree_cmd.WorktreeService",
+            return_value=mock_service,
+        ):
+            result = runner.invoke(
+                worktree_group,
+                ["add", str(tmp_path / "feature"), "--branch", "feature"],
+            )
+
+        assert result.exit_code == 0
+        assert "created" in result.output.lower()
+        mock_service.create.assert_called_once()
+
+    def test_add_with_new_branch(self, runner, tmp_path):
+        mock_service = MagicMock()
+        wt = _make_worktree(
+            str(tmp_path / "new-feat"),
+            branch="refs/heads/new-feat",
+            is_main=False,
+        )
+        mock_service.create.return_value = Success(wt)
+
+        with patch(
+            "context_harness.interfaces.cli.worktree_cmd.WorktreeService",
+            return_value=mock_service,
+        ):
+            result = runner.invoke(
+                worktree_group,
+                ["add", str(tmp_path / "new-feat"), "--new-branch", "new-feat"],
+            )
+
+        assert result.exit_code == 0
+
+    def test_add_fails_with_both_branch_flags(self, runner, tmp_path):
+        """Cannot specify both --branch and --new-branch."""
+        with patch(
+            "context_harness.interfaces.cli.worktree_cmd.WorktreeService",
+            return_value=MagicMock(),
+        ):
+            result = runner.invoke(
+                worktree_group,
+                [
+                    "add",
+                    str(tmp_path / "x"),
+                    "--branch",
+                    "a",
+                    "--new-branch",
+                    "b",
+                ],
+            )
+
+        assert result.exit_code == 1
+
+    def test_add_failure(self, runner, tmp_path):
+        mock_service = MagicMock()
+        mock_service.create.return_value = Failure(
+            error="Branch already checked out",
+            code=ErrorCode.WORKTREE_BRANCH_IN_USE,
+        )
+
+        with patch(
+            "context_harness.interfaces.cli.worktree_cmd.WorktreeService",
+            return_value=mock_service,
+        ):
+            result = runner.invoke(
+                worktree_group,
+                ["add", str(tmp_path / "feat"), "--branch", "feature"],
+            )
+
+        assert result.exit_code == 1
+
+    def test_add_shows_next_steps(self, runner, tmp_path):
+        mock_service = MagicMock()
+        wt = _make_worktree(
+            str(tmp_path / "feat"),
+            branch="refs/heads/feat",
+            is_main=False,
+        )
+        mock_service.create.return_value = Success(wt)
+
+        with patch(
+            "context_harness.interfaces.cli.worktree_cmd.WorktreeService",
+            return_value=mock_service,
+        ):
+            result = runner.invoke(
+                worktree_group,
+                ["add", str(tmp_path / "feat"), "--branch", "feat"],
+            )
+
+        assert result.exit_code == 0
+        assert "Next steps" in result.output
+
+
+# ---------------------------------------------------------------------------
+# worktree remove
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreeRemoveCmd:
+    """Tests for `worktree remove` command."""
+
+    def test_remove_success(self, runner, tmp_path):
+        mock_service = MagicMock()
+        mock_service.remove.return_value = Success(None)
+
+        with patch(
+            "context_harness.interfaces.cli.worktree_cmd.WorktreeService",
+            return_value=mock_service,
+        ):
+            result = runner.invoke(
+                worktree_group, ["remove", str(tmp_path / "feature")]
+            )
+
+        assert result.exit_code == 0
+        assert "removed" in result.output.lower()
+
+    def test_remove_dirty_fails(self, runner, tmp_path):
+        mock_service = MagicMock()
+        mock_service.remove.return_value = Failure(
+            error="contains uncommitted changes",
+            code=ErrorCode.WORKTREE_DIRTY,
+        )
+
+        with patch(
+            "context_harness.interfaces.cli.worktree_cmd.WorktreeService",
+            return_value=mock_service,
+        ):
+            result = runner.invoke(
+                worktree_group, ["remove", str(tmp_path / "feature")]
+            )
+
+        assert result.exit_code == 1
+        assert "--force" in result.output
+
+    def test_remove_force_flag(self, runner, tmp_path):
+        mock_service = MagicMock()
+        mock_service.remove.return_value = Success(None)
+
+        with patch(
+            "context_harness.interfaces.cli.worktree_cmd.WorktreeService",
+            return_value=mock_service,
+        ):
+            result = runner.invoke(
+                worktree_group, ["remove", str(tmp_path / "feature"), "--force"]
+            )
+
+        assert result.exit_code == 0
+        mock_service.remove.assert_called_once()
+        call_kwargs = mock_service.remove.call_args
+        assert call_kwargs[1].get("force") is True or (
+            len(call_kwargs[0]) >= 2 and call_kwargs[0][1] is True
+        )
+
+
+# ---------------------------------------------------------------------------
+# worktree prune
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreePruneCmd:
+    """Tests for `worktree prune` command."""
+
+    def test_prune_success(self, runner):
+        mock_service = MagicMock()
+        mock_service.prune.return_value = Success(None)
+
+        with patch(
+            "context_harness.interfaces.cli.worktree_cmd.WorktreeService",
+            return_value=mock_service,
+        ):
+            result = runner.invoke(worktree_group, ["prune"])
+
+        assert result.exit_code == 0
+        assert "cleaned up" in result.output.lower()
+
+    def test_prune_failure(self, runner):
+        mock_service = MagicMock()
+        mock_service.prune.return_value = Failure(
+            error="Not a git repository", code=ErrorCode.NOT_A_GIT_REPO
+        )
+
+        with patch(
+            "context_harness.interfaces.cli.worktree_cmd.WorktreeService",
+            return_value=mock_service,
+        ):
+            result = runner.invoke(worktree_group, ["prune"])
+
+        assert result.exit_code == 1

--- a/tests/unit/primitives/test_tool_detector.py
+++ b/tests/unit/primitives/test_tool_detector.py
@@ -1,0 +1,413 @@
+"""Unit tests for ToolDetector, ToolPaths, DetectedTools, and convenience functions.
+
+Tests cover:
+- ToolType enum values
+- ToolPaths factory methods (.for_opencode, .for_claude_code) and path correctness
+- DetectedTools properties (any_installed, both_installed, installed_tools, get_paths)
+- ToolDetector.detect() with various directory configurations
+- ToolDetector.get_skills_dirs() with explicit targets and auto-detect
+- ToolDetector.get_mcp_config_paths() with explicit targets and auto-detect
+- ToolDetector.resolve_skill_install_dir() with explicit targets and auto-detect
+- ToolDetector.get_memory_file_path() with explicit targets and auto-detect
+- ToolDetector.get_opencode_paths() / get_claude_code_paths() accessors
+- Convenience functions: detect_tools(), get_skills_dir(), get_all_skills_dirs()
+"""
+
+from pathlib import Path
+
+import pytest
+
+from context_harness.primitives.tool_detector import (
+    DetectedTools,
+    ToolDetector,
+    ToolPaths,
+    ToolType,
+    detect_tools,
+    get_all_skills_dirs,
+    get_skills_dir,
+)
+
+
+# ---------------------------------------------------------------------------
+# ToolType
+# ---------------------------------------------------------------------------
+
+
+class TestToolType:
+    """Tests for ToolType enum."""
+
+    def test_opencode_value(self):
+        assert ToolType.OPENCODE.value == "opencode"
+
+    def test_claude_code_value(self):
+        assert ToolType.CLAUDE_CODE.value == "claude-code"
+
+    def test_is_string_enum(self):
+        assert isinstance(ToolType.OPENCODE, str)
+        assert ToolType.OPENCODE == "opencode"
+
+
+# ---------------------------------------------------------------------------
+# ToolPaths
+# ---------------------------------------------------------------------------
+
+
+class TestToolPaths:
+    """Tests for ToolPaths factory methods."""
+
+    def test_for_opencode_paths(self, tmp_path):
+        paths = ToolPaths.for_opencode(tmp_path)
+
+        assert paths.tool == ToolType.OPENCODE
+        assert paths.config_dir == tmp_path / ".opencode"
+        assert paths.skills_dir == tmp_path / ".opencode" / "skill"
+        assert paths.agents_dir == tmp_path / ".opencode" / "agent"
+        assert paths.commands_dir == tmp_path / ".opencode" / "command"
+        assert paths.mcp_config == tmp_path / "opencode.json"
+        assert paths.memory_file == tmp_path / "AGENTS.md"
+
+    def test_for_claude_code_paths(self, tmp_path):
+        paths = ToolPaths.for_claude_code(tmp_path)
+
+        assert paths.tool == ToolType.CLAUDE_CODE
+        assert paths.config_dir == tmp_path / ".claude"
+        assert paths.skills_dir == tmp_path / ".claude" / "skills"
+        assert paths.agents_dir == tmp_path / ".claude" / "agents"
+        assert paths.commands_dir == tmp_path / ".claude" / "commands"
+        assert paths.mcp_config == tmp_path / ".mcp.json"
+        assert paths.memory_file == tmp_path / "CLAUDE.md"
+
+    def test_opencode_uses_singular_directories(self, tmp_path):
+        """OpenCode uses singular names (skill, agent, command)."""
+        paths = ToolPaths.for_opencode(tmp_path)
+        assert paths.skills_dir.name == "skill"
+        assert paths.agents_dir.name == "agent"
+        assert paths.commands_dir.name == "command"
+
+    def test_claude_code_uses_plural_directories(self, tmp_path):
+        """Claude Code uses plural names (skills, agents, commands)."""
+        paths = ToolPaths.for_claude_code(tmp_path)
+        assert paths.skills_dir.name == "skills"
+        assert paths.agents_dir.name == "agents"
+        assert paths.commands_dir.name == "commands"
+
+    def test_frozen_dataclass(self, tmp_path):
+        """ToolPaths is frozen — attributes cannot be reassigned."""
+        paths = ToolPaths.for_opencode(tmp_path)
+        with pytest.raises(AttributeError):
+            paths.tool = ToolType.CLAUDE_CODE  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# DetectedTools
+# ---------------------------------------------------------------------------
+
+
+class TestDetectedTools:
+    """Tests for DetectedTools properties."""
+
+    @pytest.fixture
+    def _both_paths(self, tmp_path):
+        return (
+            ToolPaths.for_opencode(tmp_path),
+            ToolPaths.for_claude_code(tmp_path),
+        )
+
+    # -- any_installed --
+    def test_any_installed_both(self, _both_paths):
+        oc, cc = _both_paths
+        d = DetectedTools(True, True, ToolType.OPENCODE, oc, cc)
+        assert d.any_installed is True
+
+    def test_any_installed_opencode_only(self, _both_paths):
+        oc, cc = _both_paths
+        d = DetectedTools(True, False, ToolType.OPENCODE, oc, cc)
+        assert d.any_installed is True
+
+    def test_any_installed_claude_only(self, _both_paths):
+        oc, cc = _both_paths
+        d = DetectedTools(False, True, ToolType.CLAUDE_CODE, oc, cc)
+        assert d.any_installed is True
+
+    def test_any_installed_none(self, _both_paths):
+        oc, cc = _both_paths
+        d = DetectedTools(False, False, None, oc, cc)
+        assert d.any_installed is False
+
+    # -- both_installed --
+    def test_both_installed_true(self, _both_paths):
+        oc, cc = _both_paths
+        d = DetectedTools(True, True, ToolType.OPENCODE, oc, cc)
+        assert d.both_installed is True
+
+    def test_both_installed_false(self, _both_paths):
+        oc, cc = _both_paths
+        d = DetectedTools(True, False, ToolType.OPENCODE, oc, cc)
+        assert d.both_installed is False
+
+    # -- installed_tools --
+    def test_installed_tools_both(self, _both_paths):
+        oc, cc = _both_paths
+        d = DetectedTools(True, True, ToolType.OPENCODE, oc, cc)
+        assert d.installed_tools == [ToolType.OPENCODE, ToolType.CLAUDE_CODE]
+
+    def test_installed_tools_none(self, _both_paths):
+        oc, cc = _both_paths
+        d = DetectedTools(False, False, None, oc, cc)
+        assert d.installed_tools == []
+
+    # -- get_paths --
+    def test_get_paths_primary(self, _both_paths):
+        oc, cc = _both_paths
+        d = DetectedTools(True, False, ToolType.OPENCODE, oc, cc)
+        assert d.get_paths() == oc
+
+    def test_get_paths_explicit_opencode(self, _both_paths):
+        oc, cc = _both_paths
+        d = DetectedTools(True, True, ToolType.OPENCODE, oc, cc)
+        assert d.get_paths(ToolType.OPENCODE) == oc
+
+    def test_get_paths_explicit_claude(self, _both_paths):
+        oc, cc = _both_paths
+        d = DetectedTools(True, True, ToolType.OPENCODE, oc, cc)
+        assert d.get_paths(ToolType.CLAUDE_CODE) == cc
+
+    def test_get_paths_returns_none_if_not_installed(self, _both_paths):
+        oc, cc = _both_paths
+        d = DetectedTools(False, False, None, oc, cc)
+        assert d.get_paths(ToolType.OPENCODE) is None
+        assert d.get_paths(ToolType.CLAUDE_CODE) is None
+
+    def test_get_paths_none_primary_returns_none(self, _both_paths):
+        oc, cc = _both_paths
+        d = DetectedTools(False, False, None, oc, cc)
+        assert d.get_paths() is None
+
+
+# ---------------------------------------------------------------------------
+# ToolDetector.detect()
+# ---------------------------------------------------------------------------
+
+
+class TestToolDetectorDetect:
+    """Tests for ToolDetector.detect()."""
+
+    def test_detect_opencode_only(self, tmp_path):
+        (tmp_path / ".opencode").mkdir()
+        detected = ToolDetector(tmp_path).detect()
+
+        assert detected.opencode is True
+        assert detected.claude_code is False
+        assert detected.primary == ToolType.OPENCODE
+
+    def test_detect_claude_code_only(self, tmp_path):
+        (tmp_path / ".claude").mkdir()
+        detected = ToolDetector(tmp_path).detect()
+
+        assert detected.opencode is False
+        assert detected.claude_code is True
+        assert detected.primary == ToolType.CLAUDE_CODE
+
+    def test_detect_both_prefers_opencode(self, tmp_path):
+        (tmp_path / ".opencode").mkdir()
+        (tmp_path / ".claude").mkdir()
+        detected = ToolDetector(tmp_path).detect()
+
+        assert detected.opencode is True
+        assert detected.claude_code is True
+        assert detected.primary == ToolType.OPENCODE
+
+    def test_detect_neither(self, tmp_path):
+        detected = ToolDetector(tmp_path).detect()
+
+        assert detected.opencode is False
+        assert detected.claude_code is False
+        assert detected.primary is None
+
+    def test_detect_resolves_path(self, tmp_path):
+        """Detector resolves symlinks / relative segments."""
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".opencode").mkdir()
+
+        # Use a path with a '..' component
+        indirect = tmp_path / "project" / "subdir" / ".."
+        indirect.mkdir(parents=True, exist_ok=True)
+        detector = ToolDetector(indirect)
+
+        detected = detector.detect()
+        assert detected.opencode is True
+
+
+# ---------------------------------------------------------------------------
+# ToolDetector.get_skills_dirs()
+# ---------------------------------------------------------------------------
+
+
+class TestToolDetectorGetSkillsDirs:
+    """Tests for ToolDetector.get_skills_dirs()."""
+
+    def test_explicit_opencode(self, tmp_path):
+        dirs = ToolDetector(tmp_path).get_skills_dirs("opencode")
+        assert len(dirs) == 1
+        assert dirs[0] == tmp_path / ".opencode" / "skill"
+
+    def test_explicit_claude_code(self, tmp_path):
+        dirs = ToolDetector(tmp_path).get_skills_dirs("claude-code")
+        assert len(dirs) == 1
+        assert dirs[0] == tmp_path / ".claude" / "skills"
+
+    def test_explicit_both(self, tmp_path):
+        dirs = ToolDetector(tmp_path).get_skills_dirs("both")
+        assert len(dirs) == 2
+
+    def test_auto_detect_opencode_installed(self, tmp_path):
+        (tmp_path / ".opencode").mkdir()
+        dirs = ToolDetector(tmp_path).get_skills_dirs()
+        assert len(dirs) == 1
+        assert dirs[0].name == "skill"
+
+    def test_auto_detect_none_installed(self, tmp_path):
+        dirs = ToolDetector(tmp_path).get_skills_dirs()
+        assert dirs == []
+
+
+# ---------------------------------------------------------------------------
+# ToolDetector.get_mcp_config_paths()
+# ---------------------------------------------------------------------------
+
+
+class TestToolDetectorGetMCPConfigPaths:
+    """Tests for ToolDetector.get_mcp_config_paths()."""
+
+    def test_explicit_opencode(self, tmp_path):
+        paths = ToolDetector(tmp_path).get_mcp_config_paths("opencode")
+        assert paths == [tmp_path / "opencode.json"]
+
+    def test_explicit_claude_code(self, tmp_path):
+        paths = ToolDetector(tmp_path).get_mcp_config_paths("claude-code")
+        assert paths == [tmp_path / ".mcp.json"]
+
+    def test_explicit_both(self, tmp_path):
+        paths = ToolDetector(tmp_path).get_mcp_config_paths("both")
+        assert len(paths) == 2
+        assert tmp_path / "opencode.json" in paths
+        assert tmp_path / ".mcp.json" in paths
+
+    def test_auto_detect_both_installed(self, tmp_path):
+        (tmp_path / ".opencode").mkdir()
+        (tmp_path / ".claude").mkdir()
+        paths = ToolDetector(tmp_path).get_mcp_config_paths()
+        assert len(paths) == 2
+
+    def test_auto_detect_none_installed(self, tmp_path):
+        paths = ToolDetector(tmp_path).get_mcp_config_paths()
+        assert paths == []
+
+
+# ---------------------------------------------------------------------------
+# ToolDetector.resolve_skill_install_dir()
+# ---------------------------------------------------------------------------
+
+
+class TestToolDetectorResolveSkillInstallDir:
+    """Tests for ToolDetector.resolve_skill_install_dir()."""
+
+    def test_explicit_opencode(self, tmp_path):
+        result = ToolDetector(tmp_path).resolve_skill_install_dir("opencode")
+        assert result == tmp_path / ".opencode" / "skill"
+
+    def test_explicit_claude_code(self, tmp_path):
+        result = ToolDetector(tmp_path).resolve_skill_install_dir("claude-code")
+        assert result == tmp_path / ".claude" / "skills"
+
+    def test_explicit_both_returns_opencode(self, tmp_path):
+        result = ToolDetector(tmp_path).resolve_skill_install_dir("both")
+        assert result == tmp_path / ".opencode" / "skill"
+
+    def test_auto_detect_primary(self, tmp_path):
+        (tmp_path / ".claude").mkdir()
+        result = ToolDetector(tmp_path).resolve_skill_install_dir()
+        assert result == tmp_path / ".claude" / "skills"
+
+    def test_auto_detect_none_returns_none(self, tmp_path):
+        result = ToolDetector(tmp_path).resolve_skill_install_dir()
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# ToolDetector.get_memory_file_path()
+# ---------------------------------------------------------------------------
+
+
+class TestToolDetectorGetMemoryFilePath:
+    """Tests for ToolDetector.get_memory_file_path()."""
+
+    def test_explicit_opencode(self, tmp_path):
+        result = ToolDetector(tmp_path).get_memory_file_path("opencode")
+        assert result == tmp_path / "AGENTS.md"
+
+    def test_explicit_claude_code(self, tmp_path):
+        result = ToolDetector(tmp_path).get_memory_file_path("claude-code")
+        assert result == tmp_path / "CLAUDE.md"
+
+    def test_auto_detect(self, tmp_path):
+        (tmp_path / ".opencode").mkdir()
+        result = ToolDetector(tmp_path).get_memory_file_path()
+        assert result == tmp_path / "AGENTS.md"
+
+    def test_auto_detect_none(self, tmp_path):
+        result = ToolDetector(tmp_path).get_memory_file_path()
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# ToolDetector accessor methods
+# ---------------------------------------------------------------------------
+
+
+class TestToolDetectorAccessors:
+    """Tests for get_opencode_paths / get_claude_code_paths."""
+
+    def test_get_opencode_paths_always_available(self, tmp_path):
+        paths = ToolDetector(tmp_path).get_opencode_paths()
+        assert paths.tool == ToolType.OPENCODE
+
+    def test_get_claude_code_paths_always_available(self, tmp_path):
+        paths = ToolDetector(tmp_path).get_claude_code_paths()
+        assert paths.tool == ToolType.CLAUDE_CODE
+
+
+# ---------------------------------------------------------------------------
+# Convenience functions
+# ---------------------------------------------------------------------------
+
+
+class TestConvenienceFunctions:
+    """Tests for module-level convenience functions."""
+
+    def test_detect_tools(self, tmp_path):
+        (tmp_path / ".opencode").mkdir()
+        detected = detect_tools(tmp_path)
+        assert detected.opencode is True
+
+    def test_get_skills_dir_returns_first(self, tmp_path):
+        (tmp_path / ".opencode").mkdir()
+        result = get_skills_dir(tmp_path)
+        assert result is not None
+        assert result.name == "skill"
+
+    def test_get_skills_dir_none_installed(self, tmp_path):
+        result = get_skills_dir(tmp_path)
+        assert result is None
+
+    def test_get_skills_dir_with_target(self, tmp_path):
+        result = get_skills_dir(tmp_path, "claude-code")
+        assert result is not None
+        assert result.name == "skills"
+
+    def test_get_all_skills_dirs(self, tmp_path):
+        (tmp_path / ".opencode").mkdir()
+        (tmp_path / ".claude").mkdir()
+        dirs = get_all_skills_dirs(tmp_path)
+        assert len(dirs) == 2

--- a/tests/unit/services/test_registry_client.py
+++ b/tests/unit/services/test_registry_client.py
@@ -1,0 +1,535 @@
+"""Unit tests for HttpRegistryClient and related registry abstractions.
+
+Tests cover:
+- RegistryAuth (from_dict, to_dict, get_token/username/password)
+- RegistryConfig (from_dict, to_dict, factory methods)
+- HttpRegistryClient
+  - check_auth with various auth types
+  - check_access (success / failure)
+  - fetch_manifest
+  - fetch_file
+  - fetch_directory (with listing, without listing, path traversal guards)
+  - _is_safe_path_component (security validation)
+  - _build_request (auth header construction)
+- create_registry_client factory function
+"""
+
+import base64
+import json
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+from threading import Thread
+from unittest import mock
+
+import pytest
+
+from context_harness.services.registry_client import (
+    AuthType,
+    GitHubRegistryClient,
+    HttpRegistryClient,
+    RegistryAuth,
+    RegistryConfig,
+    RegistryType,
+    create_registry_client,
+)
+
+
+# ---------------------------------------------------------------------------
+# RegistryAuth
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryAuth:
+    """Tests for RegistryAuth."""
+
+    def test_default_is_none_auth(self):
+        auth = RegistryAuth()
+        assert auth.type == AuthType.NONE
+
+    def test_from_dict_bearer(self):
+        auth = RegistryAuth.from_dict({"type": "bearer", "token_env": "MY_TOKEN"})
+        assert auth.type == AuthType.BEARER
+        assert auth.token_env == "MY_TOKEN"
+
+    def test_from_dict_api_key_custom_header(self):
+        auth = RegistryAuth.from_dict(
+            {"type": "api_key", "token_env": "KEY", "header_name": "X-Custom"}
+        )
+        assert auth.type == AuthType.API_KEY
+        assert auth.header_name == "X-Custom"
+
+    def test_from_dict_basic(self):
+        auth = RegistryAuth.from_dict(
+            {"type": "basic", "username_env": "USER", "password_env": "PASS"}
+        )
+        assert auth.type == AuthType.BASIC
+        assert auth.username_env == "USER"
+        assert auth.password_env == "PASS"
+
+    def test_from_dict_unknown_type_defaults_none(self):
+        auth = RegistryAuth.from_dict({"type": "kerberos"})
+        assert auth.type == AuthType.NONE
+
+    def test_to_dict_minimal(self):
+        auth = RegistryAuth()
+        d = auth.to_dict()
+        assert d == {"type": "none"}
+
+    def test_to_dict_bearer(self):
+        auth = RegistryAuth(type=AuthType.BEARER, token_env="TOK")
+        d = auth.to_dict()
+        assert d["type"] == "bearer"
+        assert d["token_env"] == "TOK"
+
+    def test_to_dict_custom_header_only_if_non_default(self):
+        auth = RegistryAuth(type=AuthType.API_KEY, token_env="K")
+        d = auth.to_dict()
+        assert "header_name" not in d  # default X-API-Key omitted
+
+        auth2 = RegistryAuth(type=AuthType.API_KEY, token_env="K", header_name="X-Alt")
+        d2 = auth2.to_dict()
+        assert d2["header_name"] == "X-Alt"
+
+    def test_get_token_from_env(self, monkeypatch):
+        monkeypatch.setenv("REG_TOKEN", "secret123")
+        auth = RegistryAuth(type=AuthType.BEARER, token_env="REG_TOKEN")
+        assert auth.get_token() == "secret123"
+
+    def test_get_token_missing_env(self, monkeypatch):
+        monkeypatch.delenv("REG_TOKEN", raising=False)
+        auth = RegistryAuth(type=AuthType.BEARER, token_env="REG_TOKEN")
+        assert auth.get_token() is None
+
+    def test_get_token_no_env_configured(self):
+        auth = RegistryAuth()
+        assert auth.get_token() is None
+
+    def test_get_username_from_env(self, monkeypatch):
+        monkeypatch.setenv("REG_USER", "admin")
+        auth = RegistryAuth(type=AuthType.BASIC, username_env="REG_USER")
+        assert auth.get_username() == "admin"
+
+    def test_get_password_from_env(self, monkeypatch):
+        monkeypatch.setenv("REG_PASS", "hunter2")
+        auth = RegistryAuth(type=AuthType.BASIC, password_env="REG_PASS")
+        assert auth.get_password() == "hunter2"
+
+
+# ---------------------------------------------------------------------------
+# RegistryConfig
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryConfig:
+    """Tests for RegistryConfig."""
+
+    def test_default_is_github(self):
+        config = RegistryConfig()
+        assert config.type == RegistryType.GITHUB
+
+    def test_from_dict_github(self):
+        config = RegistryConfig.from_dict({"type": "github", "url": "owner/repo"})
+        assert config.type == RegistryType.GITHUB
+        assert config.url == "owner/repo"
+
+    def test_from_dict_http_with_auth(self):
+        config = RegistryConfig.from_dict(
+            {
+                "type": "http",
+                "url": "https://registry.example.com",
+                "auth": {"type": "bearer", "token_env": "TOK"},
+            }
+        )
+        assert config.type == RegistryType.HTTP
+        assert config.auth.type == AuthType.BEARER
+
+    def test_from_dict_unknown_type_defaults_github(self):
+        config = RegistryConfig.from_dict({"type": "s3", "url": "bucket/path"})
+        assert config.type == RegistryType.GITHUB
+
+    def test_to_dict_github_no_auth(self):
+        config = RegistryConfig.github("owner/repo")
+        d = config.to_dict()
+        assert d == {"type": "github", "url": "owner/repo"}
+        assert "auth" not in d
+
+    def test_to_dict_http_with_auth(self):
+        auth = RegistryAuth(type=AuthType.BEARER, token_env="TOK")
+        config = RegistryConfig.http("https://example.com", auth)
+        d = config.to_dict()
+        assert d["type"] == "http"
+        assert "auth" in d
+        assert d["auth"]["type"] == "bearer"
+
+    def test_github_factory(self):
+        config = RegistryConfig.github("org/skills")
+        assert config.type == RegistryType.GITHUB
+        assert config.url == "org/skills"
+
+    def test_http_factory_no_auth(self):
+        config = RegistryConfig.http("https://example.com")
+        assert config.type == RegistryType.HTTP
+        assert config.auth.type == AuthType.NONE
+
+
+# ---------------------------------------------------------------------------
+# HttpRegistryClient._is_safe_path_component
+# ---------------------------------------------------------------------------
+
+
+class TestHttpClientSafePath:
+    """Tests for path traversal protection."""
+
+    @pytest.fixture
+    def client(self):
+        return HttpRegistryClient("https://example.com")
+
+    @pytest.mark.parametrize(
+        "component,expected",
+        [
+            ("SKILL.md", True),
+            ("version.txt", True),
+            ("references", True),
+            ("my-skill-v2", True),
+            ("", False),
+            ("..", False),
+            ("../etc/passwd", False),
+            ("foo/bar", False),
+            ("foo\\bar", False),
+            ("/absolute", False),
+            ("\\backslash", False),
+            ("..sneaky", False),
+            ("path/../traverse", False),
+        ],
+    )
+    def test_is_safe_path_component(self, client, component, expected):
+        assert client._is_safe_path_component(component) is expected
+
+
+# ---------------------------------------------------------------------------
+# HttpRegistryClient.check_auth
+# ---------------------------------------------------------------------------
+
+
+class TestHttpClientCheckAuth:
+    """Tests for check_auth with different auth types."""
+
+    def test_no_auth_always_true(self):
+        client = HttpRegistryClient("https://example.com")
+        assert client.check_auth() is True
+
+    def test_bearer_with_token(self, monkeypatch):
+        monkeypatch.setenv("MY_TOK", "secret")
+        auth = RegistryAuth(type=AuthType.BEARER, token_env="MY_TOK")
+        client = HttpRegistryClient("https://example.com", auth)
+        assert client.check_auth() is True
+
+    def test_bearer_without_token(self, monkeypatch):
+        monkeypatch.delenv("MY_TOK", raising=False)
+        auth = RegistryAuth(type=AuthType.BEARER, token_env="MY_TOK")
+        client = HttpRegistryClient("https://example.com", auth)
+        assert client.check_auth() is False
+
+    def test_api_key_with_token(self, monkeypatch):
+        monkeypatch.setenv("API_KEY", "k")
+        auth = RegistryAuth(type=AuthType.API_KEY, token_env="API_KEY")
+        client = HttpRegistryClient("https://example.com", auth)
+        assert client.check_auth() is True
+
+    def test_api_key_without_token(self, monkeypatch):
+        monkeypatch.delenv("API_KEY", raising=False)
+        auth = RegistryAuth(type=AuthType.API_KEY, token_env="API_KEY")
+        client = HttpRegistryClient("https://example.com", auth)
+        assert client.check_auth() is False
+
+    def test_basic_with_both_credentials(self, monkeypatch):
+        monkeypatch.setenv("U", "user")
+        monkeypatch.setenv("P", "pass")
+        auth = RegistryAuth(type=AuthType.BASIC, username_env="U", password_env="P")
+        client = HttpRegistryClient("https://example.com", auth)
+        assert client.check_auth() is True
+
+    def test_basic_missing_password(self, monkeypatch):
+        monkeypatch.setenv("U", "user")
+        monkeypatch.delenv("P", raising=False)
+        auth = RegistryAuth(type=AuthType.BASIC, username_env="U", password_env="P")
+        client = HttpRegistryClient("https://example.com", auth)
+        assert client.check_auth() is False
+
+
+# ---------------------------------------------------------------------------
+# HttpRegistryClient._build_request (auth headers)
+# ---------------------------------------------------------------------------
+
+
+class TestHttpClientBuildRequest:
+    """Tests for _build_request auth header construction."""
+
+    def test_no_auth_no_headers(self):
+        client = HttpRegistryClient("https://example.com")
+        req = client._build_request("https://example.com/test")
+        assert req.get_header("Authorization") is None
+
+    def test_bearer_header(self, monkeypatch):
+        monkeypatch.setenv("TOK", "my-bearer-token")
+        auth = RegistryAuth(type=AuthType.BEARER, token_env="TOK")
+        client = HttpRegistryClient("https://example.com", auth)
+        req = client._build_request("https://example.com/test")
+        assert req.get_header("Authorization") == "Bearer my-bearer-token"
+
+    def test_api_key_header(self, monkeypatch):
+        monkeypatch.setenv("KEY", "my-api-key")
+        auth = RegistryAuth(type=AuthType.API_KEY, token_env="KEY")
+        client = HttpRegistryClient("https://example.com", auth)
+        req = client._build_request("https://example.com/test")
+        assert req.get_header("X-api-key") == "my-api-key"
+
+    def test_api_key_custom_header(self, monkeypatch):
+        monkeypatch.setenv("KEY", "val")
+        auth = RegistryAuth(
+            type=AuthType.API_KEY, token_env="KEY", header_name="X-Custom"
+        )
+        client = HttpRegistryClient("https://example.com", auth)
+        req = client._build_request("https://example.com/test")
+        assert req.get_header("X-custom") == "val"
+
+    def test_basic_auth_header(self, monkeypatch):
+        monkeypatch.setenv("U", "admin")
+        monkeypatch.setenv("P", "secret")
+        auth = RegistryAuth(type=AuthType.BASIC, username_env="U", password_env="P")
+        client = HttpRegistryClient("https://example.com", auth)
+        req = client._build_request("https://example.com/test")
+
+        expected = base64.b64encode(b"admin:secret").decode("ascii")
+        assert req.get_header("Authorization") == f"Basic {expected}"
+
+    def test_bearer_missing_token_no_header(self, monkeypatch):
+        monkeypatch.delenv("TOK", raising=False)
+        auth = RegistryAuth(type=AuthType.BEARER, token_env="TOK")
+        client = HttpRegistryClient("https://example.com", auth)
+        req = client._build_request("https://example.com/test")
+        assert req.get_header("Authorization") is None
+
+
+# ---------------------------------------------------------------------------
+# HttpRegistryClient.check_access, fetch_manifest, fetch_file
+# (mocked HTTP layer)
+# ---------------------------------------------------------------------------
+
+
+class TestHttpClientNetworkOps:
+    """Tests for network operations using mocked urlopen."""
+
+    def test_check_access_success(self):
+        client = HttpRegistryClient("https://registry.example.com")
+        mock_response = mock.MagicMock()
+        mock_response.status = 200
+        mock_response.__enter__ = mock.MagicMock(return_value=mock_response)
+        mock_response.__exit__ = mock.MagicMock(return_value=False)
+
+        with mock.patch(
+            "context_harness.services.registry_client.urlopen",
+            return_value=mock_response,
+        ):
+            assert client.check_access() is True
+
+    def test_check_access_failure(self):
+        from urllib.error import URLError
+
+        client = HttpRegistryClient("https://registry.example.com")
+        with mock.patch(
+            "context_harness.services.registry_client.urlopen",
+            side_effect=URLError("connection refused"),
+        ):
+            assert client.check_access() is False
+
+    def test_fetch_manifest_success(self):
+        manifest = json.dumps({"skills": [{"name": "my-skill"}]})
+        client = HttpRegistryClient("https://registry.example.com")
+
+        mock_response = mock.MagicMock()
+        mock_response.read.return_value = manifest.encode("utf-8")
+        mock_response.__enter__ = mock.MagicMock(return_value=mock_response)
+        mock_response.__exit__ = mock.MagicMock(return_value=False)
+
+        with mock.patch(
+            "context_harness.services.registry_client.urlopen",
+            return_value=mock_response,
+        ):
+            result = client.fetch_manifest()
+            assert result is not None
+            parsed = json.loads(result)
+            assert parsed["skills"][0]["name"] == "my-skill"
+
+    def test_fetch_manifest_failure(self):
+        from urllib.error import HTTPError
+
+        client = HttpRegistryClient("https://registry.example.com")
+        with mock.patch(
+            "context_harness.services.registry_client.urlopen",
+            side_effect=HTTPError(None, 404, "Not Found", {}, None),
+        ):
+            assert client.fetch_manifest() is None
+
+    def test_fetch_file_success(self):
+        content = b"# My Skill\nSome content"
+        client = HttpRegistryClient("https://registry.example.com")
+
+        mock_response = mock.MagicMock()
+        mock_response.read.return_value = content
+        mock_response.__enter__ = mock.MagicMock(return_value=mock_response)
+        mock_response.__exit__ = mock.MagicMock(return_value=False)
+
+        with mock.patch(
+            "context_harness.services.registry_client.urlopen",
+            return_value=mock_response,
+        ):
+            result = client.fetch_file("skill/my-skill/SKILL.md")
+            assert result == content
+
+    def test_fetch_file_failure(self):
+        from urllib.error import HTTPError
+
+        client = HttpRegistryClient("https://registry.example.com")
+        with mock.patch(
+            "context_harness.services.registry_client.urlopen",
+            side_effect=HTTPError(None, 404, "Not Found", {}, None),
+        ):
+            assert client.fetch_file("nonexistent") is None
+
+    def test_base_url_trailing_slash_stripped(self):
+        client = HttpRegistryClient("https://example.com/skills/")
+        assert client.base_url == "https://example.com/skills"
+
+
+# ---------------------------------------------------------------------------
+# HttpRegistryClient.fetch_directory
+# ---------------------------------------------------------------------------
+
+
+class TestHttpClientFetchDirectory:
+    """Tests for fetch_directory."""
+
+    def test_fetch_directory_with_listing(self, tmp_path):
+        """When .listing.json is available, uses it."""
+        client = HttpRegistryClient("https://example.com")
+
+        listing_data = json.dumps(
+            {"files": ["SKILL.md", "version.txt", "extra.txt"], "directories": []}
+        )
+
+        def mock_fetch_file(path):
+            if path.endswith(".listing.json"):
+                return listing_data.encode("utf-8")
+            elif path.endswith("SKILL.md"):
+                return b"# Skill"
+            elif path.endswith("version.txt"):
+                return b"1.0.0"
+            elif path.endswith("extra.txt"):
+                return b"extra content"
+            return None
+
+        with mock.patch.object(client, "_fetch_file", side_effect=mock_fetch_file):
+            dest = tmp_path / "skill-out"
+            result = client.fetch_directory("skill/test", dest)
+
+        assert result is True
+        assert (dest / "SKILL.md").exists()
+        assert (dest / "version.txt").exists()
+        assert (dest / "extra.txt").exists()
+
+    def test_fetch_directory_without_listing_falls_back(self, tmp_path):
+        """When no .listing.json, fetches common files."""
+        client = HttpRegistryClient("https://example.com")
+
+        def mock_fetch_file(path):
+            if path.endswith(".listing.json"):
+                return None  # No listing available
+            elif path.endswith("SKILL.md"):
+                return b"# Skill Content"
+            elif path.endswith("version.txt"):
+                return b"2.0.0"
+            return None
+
+        with mock.patch.object(client, "_fetch_file", side_effect=mock_fetch_file):
+            dest = tmp_path / "skill-out"
+            result = client.fetch_directory("skill/test", dest)
+
+        assert result is True
+        assert (dest / "SKILL.md").exists()
+
+    def test_fetch_directory_no_skill_md_returns_false(self, tmp_path):
+        """If SKILL.md cannot be fetched, returns False."""
+        client = HttpRegistryClient("https://example.com")
+
+        with mock.patch.object(client, "_fetch_file", return_value=None):
+            dest = tmp_path / "empty-out"
+            result = client.fetch_directory("skill/missing", dest)
+
+        assert result is False
+
+    def test_fetch_directory_skips_unsafe_filenames(self, tmp_path):
+        """Path traversal filenames in listing are skipped."""
+        client = HttpRegistryClient("https://example.com")
+
+        listing_data = json.dumps(
+            {
+                "files": ["SKILL.md", "../etc/passwd", "version.txt"],
+                "directories": ["../sneaky"],
+            }
+        )
+
+        def mock_fetch_file(path):
+            if path.endswith(".listing.json"):
+                return listing_data.encode("utf-8")
+            elif path.endswith("SKILL.md"):
+                return b"# Skill"
+            elif path.endswith("version.txt"):
+                return b"1.0.0"
+            return None
+
+        with mock.patch.object(client, "_fetch_file", side_effect=mock_fetch_file):
+            dest = tmp_path / "safe-out"
+            result = client.fetch_directory("skill/test", dest)
+
+        assert result is True
+        assert (dest / "SKILL.md").exists()
+        # Traversal files should NOT exist
+        assert not (dest / ".." / "etc" / "passwd").exists()
+
+
+# ---------------------------------------------------------------------------
+# create_registry_client factory
+# ---------------------------------------------------------------------------
+
+
+class TestCreateRegistryClient:
+    """Tests for create_registry_client factory."""
+
+    def test_creates_github_client(self):
+        config = RegistryConfig.github("org/repo")
+        client = create_registry_client(config)
+        assert isinstance(client, GitHubRegistryClient)
+        assert client.repo == "org/repo"
+
+    def test_creates_http_client(self):
+        config = RegistryConfig.http("https://example.com")
+        client = create_registry_client(config)
+        assert isinstance(client, HttpRegistryClient)
+        assert client.base_url == "https://example.com"
+
+    def test_http_client_receives_auth(self, monkeypatch):
+        monkeypatch.setenv("TOK", "val")
+        auth = RegistryAuth(type=AuthType.BEARER, token_env="TOK")
+        config = RegistryConfig.http("https://example.com", auth)
+        client = create_registry_client(config)
+        assert isinstance(client, HttpRegistryClient)
+        assert client.auth.type == AuthType.BEARER
+
+    def test_unknown_type_defaults_to_github(self):
+        """Fallback: unknown registry type creates GitHub client."""
+        config = RegistryConfig()
+        config.type = RegistryType.GITHUB
+        config.url = "fallback/repo"
+        client = create_registry_client(config)
+        assert isinstance(client, GitHubRegistryClient)

--- a/tests/unit/services/test_skill_service.py
+++ b/tests/unit/services/test_skill_service.py
@@ -2332,3 +2332,38 @@ class TestSkillServiceUpgradeRegistryRepo:
         # Existing skills list should be preserved (not wiped)
         assert len(data["skills"]) == 1
         assert data["skills"][0]["name"] == "existing-skill"
+
+    def test_upgrade_regenerates_per_skill_plugin_json(self, tmp_path: Path) -> None:
+        """Upgrade creates .claude-plugin/plugin.json for each skill."""
+        service = SkillService(github_client=MockGitHubClient())
+
+        (tmp_path / "skills.json").write_text('{"skills": []}')
+        (tmp_path / "skill").mkdir()
+
+        # Create two skills — one with existing plugin.json, one without
+        for name, desc, ver in [
+            ("alpha-skill", "First skill", "1.0.0"),
+            ("beta-skill", "Second skill", "2.0.0"),
+        ]:
+            d = tmp_path / "skill" / name
+            d.mkdir()
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {desc}\n---\n# {name}\n"
+            )
+            (d / "version.txt").write_text(ver)
+
+        result = service.upgrade_registry_repo(tmp_path)
+
+        assert isinstance(result, Success)
+
+        # Both skills should have .claude-plugin/plugin.json
+        for name in ["alpha-skill", "beta-skill"]:
+            plugin_json = tmp_path / "skill" / name / ".claude-plugin" / "plugin.json"
+            assert plugin_json.exists(), f"Missing plugin.json for {name}"
+            data = json.loads(plugin_json.read_text())
+            assert data["name"] == name
+
+        # Per-skill plugin.json files should be in updated files list
+        updated = result.value["files_updated"]
+        assert "skill/alpha-skill/.claude-plugin/plugin.json" in updated
+        assert "skill/beta-skill/.claude-plugin/plugin.json" in updated

--- a/tests/unit/services/test_skill_service.py
+++ b/tests/unit/services/test_skill_service.py
@@ -1219,7 +1219,7 @@ class TestSkillServiceInitRegistryRepo:
             ".github/workflows/release.yml",
             ".github/workflows/sync-registry.yml",
             ".github/workflows/validate-skills.yml",
-            ".github/workflows/auto-rebase.yml",
+            ".github/workflows/skill-onboarding.md",
             "scripts/sync-registry.py",
             "scripts/validate_skills.py",
             "skill/example-skill/SKILL.md",
@@ -1532,18 +1532,21 @@ class TestSkillServiceInitRegistryRepo:
         assert "marocchino/sticky-pull-request-comment@v2" in content
         assert "contents: read" in content
 
-    def test_scaffold_auto_rebase_workflow(self, tmp_path: Path) -> None:
-        """auto-rebase.yml automatically rebases PRs when shared files change."""
+    def test_scaffold_skill_onboarding_workflow(self, tmp_path: Path) -> None:
+        """skill-onboarding.md agentic workflow auto-registers new skills."""
         service = SkillService(github_client=MockGitHubClient())
         service._write_registry_scaffold(tmp_path, "test-user/my-skills")
 
-        content = (tmp_path / ".github" / "workflows" / "auto-rebase.yml").read_text()
-        assert "Auto Rebase" in content
-        assert "skills.json" in content
+        content = (
+            tmp_path / ".github" / "workflows" / "skill-onboarding.md"
+        ).read_text()
+        assert "Skill Onboarding" in content
         assert "release-please-config.json" in content
         assert ".release-please-manifest.json" in content
-        assert "git rebase origin/main" in content
-        assert "force-with-lease" in content
+        assert "version.txt" in content
+        assert "push-to-pull-request-branch" in content
+        assert "pull_request" in content
+        assert "skill/**" in content
 
     def test_scaffold_sync_registry_script(self, tmp_path: Path) -> None:
         """sync-registry.py parses frontmatter and version.txt."""
@@ -1701,7 +1704,7 @@ class TestSkillServiceInitRegistryRepo:
     # -- Subprocess call verification ----------------------------------------
 
     def test_init_repo_calls_clone_add_commit_push(self) -> None:
-        """Subprocess calls are made in correct order: clone, add, commit, push."""
+        """Subprocess calls are made in correct order: clone, compile, add, commit, push."""
         client = MockGitHubClient(
             has_repo_access=False,
             create_repo_url="https://github.com/test-user/my-skills",
@@ -1712,22 +1715,25 @@ class TestSkillServiceInitRegistryRepo:
             mock_run.return_value.returncode = 0
             service.init_registry_repo("my-skills")
 
-        # Should have 4 subprocess calls: clone, add, commit, push
-        assert mock_run.call_count == 4
+        # Should have 5 subprocess calls: clone, gh aw compile, add, commit, push
+        assert mock_run.call_count == 5
 
         calls = [c.args[0] for c in mock_run.call_args_list]
         # First call: gh repo clone
         assert calls[0][0] == "gh"
         assert "clone" in calls[0]
-        # Second call: git add
-        assert calls[1][0] == "git"
-        assert "add" in calls[1]
-        # Third call: git commit
+        # Second call: gh aw compile (best-effort)
+        assert calls[1][0] == "gh"
+        assert "aw" in calls[1]
+        # Third call: git add
         assert calls[2][0] == "git"
-        assert "commit" in calls[2]
-        # Fourth call: git push
+        assert "add" in calls[2]
+        # Fourth call: git commit
         assert calls[3][0] == "git"
-        assert "push" in calls[3]
+        assert "commit" in calls[3]
+        # Fifth call: git push
+        assert calls[4][0] == "git"
+        assert "push" in calls[4]
 
     def test_init_repo_private_flag_passed_to_create(self) -> None:
         """Private=True is passed through to create_repo."""
@@ -1893,7 +1899,7 @@ class TestSkillServiceUpgradeRegistryRepo:
         assert ".github/workflows/release.yml" in files
         assert ".github/workflows/sync-registry.yml" in files
         assert ".github/workflows/validate-skills.yml" in files
-        assert ".github/workflows/auto-rebase.yml" in files
+        assert ".github/workflows/skill-onboarding.md" in files
 
         # GitHub templates
         assert ".github/ISSUE_TEMPLATE/new-skill.md" in files
@@ -2034,6 +2040,7 @@ class TestSkillServiceUpgradeRegistryRepo:
         assert "Dockerfile" in files
         assert "docker-compose.yml" in files
         assert "registry/nginx.conf" in files
+        assert ".github/workflows/skill-onboarding.md" in files
 
         # Non-critical existing files are NOT included without force
         assert ".github/workflows/release.yml" not in files

--- a/tests/unit/services/test_skill_service.py
+++ b/tests/unit/services/test_skill_service.py
@@ -1287,6 +1287,87 @@ class TestSkillServiceInitRegistryRepo:
         assert "registry_version" in content
         assert content["schema_version"] == "1.1"
 
+    def test_scaffold_claude_plugin_marketplace_created(self, tmp_path: Path) -> None:
+        """Scaffold creates .claude-plugin/marketplace.json conforming to Claude Code standard."""
+        service = SkillService(github_client=MockGitHubClient())
+        service._write_registry_scaffold(tmp_path, "test-user/my-skills")
+
+        mkt_path = tmp_path / ".claude-plugin" / "marketplace.json"
+        assert mkt_path.exists()
+
+        content = json.loads(mkt_path.read_text())
+        # Required fields per Claude Code plugin marketplace standard
+        assert "name" in content
+        assert "owner" in content
+        assert "plugins" in content
+        assert isinstance(content["plugins"], list)
+        assert content["name"] == "my-skills"
+        assert content["owner"]["name"] == "test-user"
+
+    def test_scaffold_claude_plugin_marketplace_has_plugin_entries(
+        self, tmp_path: Path
+    ) -> None:
+        """Each skill directory becomes a plugin entry in .claude-plugin/marketplace.json."""
+        service = SkillService(github_client=MockGitHubClient())
+        service._write_registry_scaffold(tmp_path, "test-user/my-skills")
+
+        content = json.loads(
+            (tmp_path / ".claude-plugin" / "marketplace.json").read_text()
+        )
+        plugins = content["plugins"]
+        # Should have at least the example-skill
+        plugin_names = [p["name"] for p in plugins]
+        assert "example-skill" in plugin_names
+
+        # Each plugin must have name and source (Claude Code standard)
+        for plugin in plugins:
+            assert "name" in plugin
+            assert "source" in plugin
+            assert plugin["source"].startswith("./skill/")
+
+    def test_scaffold_claude_plugin_marketplace_metadata(self, tmp_path: Path) -> None:
+        """.claude-plugin/marketplace.json includes optional metadata fields."""
+        service = SkillService(github_client=MockGitHubClient())
+        service._write_registry_scaffold(tmp_path, "test-user/my-skills")
+
+        content = json.loads(
+            (tmp_path / ".claude-plugin" / "marketplace.json").read_text()
+        )
+        assert "metadata" in content
+        assert "description" in content["metadata"]
+        assert "version" in content["metadata"]
+        assert "pluginRoot" in content["metadata"]
+        assert content["metadata"]["pluginRoot"] == "./skill"
+
+    def test_scaffold_skill_plugin_json_created(self, tmp_path: Path) -> None:
+        """Each skill directory gets a .claude-plugin/plugin.json manifest."""
+        service = SkillService(github_client=MockGitHubClient())
+        service._write_registry_scaffold(tmp_path, "test-user/my-skills")
+
+        plugin_json = (
+            tmp_path / "skill" / "example-skill" / ".claude-plugin" / "plugin.json"
+        )
+        assert plugin_json.exists()
+
+        content = json.loads(plugin_json.read_text())
+        assert content["name"] == "example-skill"
+        assert "description" in content
+        assert "version" in content
+        assert content["version"] == "0.1.0"
+
+    def test_scaffold_claude_plugin_marketplace_kebab_case_name(
+        self, tmp_path: Path
+    ) -> None:
+        """Marketplace name uses kebab-case (repo name) per Claude Code standard."""
+        service = SkillService(github_client=MockGitHubClient())
+        service._write_registry_scaffold(tmp_path, "my-org/team-skills")
+
+        content = json.loads(
+            (tmp_path / ".claude-plugin" / "marketplace.json").read_text()
+        )
+        # name should be the repo name part (kebab-case)
+        assert content["name"] == "team-skills"
+
     def test_scaffold_readme_contains_repo_name(self, tmp_path: Path) -> None:
         """README.md references the repository name."""
         service = SkillService(github_client=MockGitHubClient())
@@ -1838,6 +1919,9 @@ class TestSkillServiceUpgradeRegistryRepo:
 
         # Marketplace manifest
         assert "marketplace.json" in files
+
+        # Claude Code plugin marketplace
+        assert ".claude-plugin/marketplace.json" in files
 
         # Version marker (always included)
         assert ".registry-version" in files

--- a/tests/unit/services/test_skill_service.py
+++ b/tests/unit/services/test_skill_service.py
@@ -2054,6 +2054,60 @@ class TestSkillServiceUpgradeRegistryRepo:
         assert "Dockerfile" in force_files
         assert ".github/workflows/release.yml" in force_files
 
+    def test_upgrade_removes_obsolete_auto_rebase_workflow(
+        self, tmp_path: Path
+    ) -> None:
+        """Upgrade removes auto-rebase.yml which was replaced by skill-onboarding.md."""
+        service = SkillService(github_client=MockGitHubClient())
+
+        # Create registry with old auto-rebase.yml
+        (tmp_path / ".registry-version").write_text("0.1.0")
+        (tmp_path / "skills.json").write_text('{"skills": []}')
+        (tmp_path / "skill").mkdir()
+        (tmp_path / ".github" / "workflows").mkdir(parents=True)
+        (tmp_path / ".github" / "workflows" / "auto-rebase.yml").write_text(
+            "# OLD AUTO REBASE WORKFLOW"
+        )
+
+        result = service.upgrade_registry_repo(tmp_path)
+        assert isinstance(result, Success)
+
+        # auto-rebase.yml should be deleted
+        assert not (tmp_path / ".github" / "workflows" / "auto-rebase.yml").exists()
+
+        # Removal should be reported in updated files
+        updated = result.value["files_updated"]
+        assert "(removed) .github/workflows/auto-rebase.yml" in updated
+
+    def test_upgrade_overwrites_existing_skill_onboarding_workflow(
+        self, tmp_path: Path
+    ) -> None:
+        """skill-onboarding.md is critical infrastructure and always overwritten."""
+        service = SkillService(github_client=MockGitHubClient())
+
+        # Create registry with old skill-onboarding.md content
+        (tmp_path / ".registry-version").write_text("0.1.0")
+        (tmp_path / "skills.json").write_text('{"skills": []}')
+        (tmp_path / "skill").mkdir()
+        (tmp_path / ".github" / "workflows").mkdir(parents=True)
+        (tmp_path / ".github" / "workflows" / "skill-onboarding.md").write_text(
+            "# OLD CONTENT"
+        )
+
+        result = service.upgrade_registry_repo(tmp_path)
+        assert isinstance(result, Success)
+
+        # File should be overwritten with new content
+        updated = result.value["files_updated"]
+        assert ".github/workflows/skill-onboarding.md" in updated
+
+        # Content should no longer be the old content
+        content = (
+            tmp_path / ".github" / "workflows" / "skill-onboarding.md"
+        ).read_text()
+        assert "# OLD CONTENT" not in content
+        assert "Skill Onboarding" in content
+
     def test_upgrade_regenerates_skills_json_with_full_metadata(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit/storage/test_file_storage.py
+++ b/tests/unit/storage/test_file_storage.py
@@ -1,0 +1,351 @@
+"""Unit tests for FileStorage.
+
+Tests the real-filesystem storage implementation using pytest tmp_path
+to isolate every test.  Covers:
+- Path resolution (relative, absolute)
+- read / read_bytes (happy path, missing file, permission error, directory)
+- write / write_bytes (creates parents, sets permissions)
+- delete (existing, missing, directory)
+- exists / is_file / is_dir
+- mkdir / rmdir (empty, non-empty, recursive)
+- list_dir (with files, with subdirs, missing directory)
+- glob (simple pattern, recursive, no matches)
+"""
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from context_harness.storage.file_storage import FileStorage
+
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+
+class TestFileStorageResolve:
+    """Tests for path resolution."""
+
+    def test_resolve_relative(self, tmp_path):
+        storage = FileStorage(tmp_path)
+        resolved = storage.resolve("subdir/file.txt")
+        assert resolved == tmp_path / "subdir" / "file.txt"
+
+    def test_resolve_absolute_passthrough(self, tmp_path):
+        storage = FileStorage(tmp_path)
+        abs_path = Path("/absolute/path")
+        resolved = storage.resolve(abs_path)
+        assert resolved == abs_path
+
+    def test_root_property(self, tmp_path):
+        storage = FileStorage(tmp_path)
+        assert storage.root == tmp_path.resolve()
+
+    def test_default_root_is_cwd(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        storage = FileStorage()
+        assert storage.root == Path.cwd()
+
+
+# ---------------------------------------------------------------------------
+# read / read_bytes
+# ---------------------------------------------------------------------------
+
+
+class TestFileStorageRead:
+    """Tests for read and read_bytes."""
+
+    def test_read_existing_file(self, tmp_path):
+        (tmp_path / "hello.txt").write_text("world", encoding="utf-8")
+        storage = FileStorage(tmp_path)
+        assert storage.read("hello.txt") == "world"
+
+    def test_read_missing_file(self, tmp_path):
+        storage = FileStorage(tmp_path)
+        assert storage.read("nonexistent.txt") is None
+
+    def test_read_directory_returns_none(self, tmp_path):
+        (tmp_path / "adir").mkdir()
+        storage = FileStorage(tmp_path)
+        assert storage.read("adir") is None
+
+    def test_read_bytes_existing(self, tmp_path):
+        (tmp_path / "data.bin").write_bytes(b"\x00\x01\x02")
+        storage = FileStorage(tmp_path)
+        assert storage.read_bytes("data.bin") == b"\x00\x01\x02"
+
+    def test_read_bytes_missing(self, tmp_path):
+        storage = FileStorage(tmp_path)
+        assert storage.read_bytes("nope.bin") is None
+
+    def test_read_bytes_directory_returns_none(self, tmp_path):
+        (tmp_path / "adir").mkdir()
+        storage = FileStorage(tmp_path)
+        assert storage.read_bytes("adir") is None
+
+
+# ---------------------------------------------------------------------------
+# write / write_bytes
+# ---------------------------------------------------------------------------
+
+
+class TestFileStorageWrite:
+    """Tests for write and write_bytes."""
+
+    def test_write_creates_file(self, tmp_path):
+        storage = FileStorage(tmp_path)
+        storage.write("new.txt", "content")
+        assert (tmp_path / "new.txt").read_text(encoding="utf-8") == "content"
+
+    def test_write_creates_parent_dirs(self, tmp_path):
+        storage = FileStorage(tmp_path)
+        storage.write("a/b/c/deep.txt", "deep")
+        assert (tmp_path / "a" / "b" / "c" / "deep.txt").exists()
+
+    def test_write_overwrites_existing(self, tmp_path):
+        (tmp_path / "file.txt").write_text("old", encoding="utf-8")
+        storage = FileStorage(tmp_path)
+        storage.write("file.txt", "new")
+        assert storage.read("file.txt") == "new"
+
+    def test_write_bytes_creates_file(self, tmp_path):
+        storage = FileStorage(tmp_path)
+        storage.write_bytes("data.bin", b"\xff\xfe")
+        assert (tmp_path / "data.bin").read_bytes() == b"\xff\xfe"
+
+    def test_write_bytes_creates_parent_dirs(self, tmp_path):
+        storage = FileStorage(tmp_path)
+        storage.write_bytes("x/y/data.bin", b"\x01")
+        assert (tmp_path / "x" / "y" / "data.bin").exists()
+
+
+# ---------------------------------------------------------------------------
+# delete
+# ---------------------------------------------------------------------------
+
+
+class TestFileStorageDelete:
+    """Tests for delete."""
+
+    def test_delete_existing_file(self, tmp_path):
+        (tmp_path / "doomed.txt").write_text("bye", encoding="utf-8")
+        storage = FileStorage(tmp_path)
+        assert storage.delete("doomed.txt") is True
+        assert not (tmp_path / "doomed.txt").exists()
+
+    def test_delete_missing_file(self, tmp_path):
+        storage = FileStorage(tmp_path)
+        assert storage.delete("ghost.txt") is False
+
+    def test_delete_directory_returns_false(self, tmp_path):
+        """Deleting a directory via delete() should return False (not raise)."""
+        (tmp_path / "adir").mkdir()
+        storage = FileStorage(tmp_path)
+        # On some platforms (macOS), unlink on a directory raises PermissionError
+        # rather than IsADirectoryError, but FileStorage should still return False.
+        result = storage.delete("adir")
+        assert result is False
+        assert (tmp_path / "adir").exists()
+
+
+# ---------------------------------------------------------------------------
+# exists / is_file / is_dir
+# ---------------------------------------------------------------------------
+
+
+class TestFileStorageExistence:
+    """Tests for exists, is_file, is_dir."""
+
+    def test_exists_file(self, tmp_path):
+        (tmp_path / "f.txt").write_text("x", encoding="utf-8")
+        storage = FileStorage(tmp_path)
+        assert storage.exists("f.txt") is True
+
+    def test_exists_dir(self, tmp_path):
+        (tmp_path / "d").mkdir()
+        storage = FileStorage(tmp_path)
+        assert storage.exists("d") is True
+
+    def test_exists_missing(self, tmp_path):
+        storage = FileStorage(tmp_path)
+        assert storage.exists("nope") is False
+
+    def test_is_file_true(self, tmp_path):
+        (tmp_path / "f.txt").write_text("x", encoding="utf-8")
+        storage = FileStorage(tmp_path)
+        assert storage.is_file("f.txt") is True
+
+    def test_is_file_false_for_dir(self, tmp_path):
+        (tmp_path / "d").mkdir()
+        storage = FileStorage(tmp_path)
+        assert storage.is_file("d") is False
+
+    def test_is_dir_true(self, tmp_path):
+        (tmp_path / "d").mkdir()
+        storage = FileStorage(tmp_path)
+        assert storage.is_dir("d") is True
+
+    def test_is_dir_false_for_file(self, tmp_path):
+        (tmp_path / "f.txt").write_text("x", encoding="utf-8")
+        storage = FileStorage(tmp_path)
+        assert storage.is_dir("f.txt") is False
+
+
+# ---------------------------------------------------------------------------
+# mkdir / rmdir
+# ---------------------------------------------------------------------------
+
+
+class TestFileStorageDirectories:
+    """Tests for mkdir and rmdir."""
+
+    def test_mkdir_creates_directory(self, tmp_path):
+        storage = FileStorage(tmp_path)
+        storage.mkdir("newdir")
+        assert (tmp_path / "newdir").is_dir()
+
+    def test_mkdir_creates_nested(self, tmp_path):
+        storage = FileStorage(tmp_path)
+        storage.mkdir("a/b/c")
+        assert (tmp_path / "a" / "b" / "c").is_dir()
+
+    def test_mkdir_idempotent(self, tmp_path):
+        storage = FileStorage(tmp_path)
+        storage.mkdir("d")
+        storage.mkdir("d")  # Should not raise
+        assert (tmp_path / "d").is_dir()
+
+    def test_rmdir_empty(self, tmp_path):
+        (tmp_path / "empty").mkdir()
+        storage = FileStorage(tmp_path)
+        assert storage.rmdir("empty") is True
+        assert not (tmp_path / "empty").exists()
+
+    def test_rmdir_nonempty_fails_without_recursive(self, tmp_path):
+        d = tmp_path / "nonempty"
+        d.mkdir()
+        (d / "file.txt").write_text("x", encoding="utf-8")
+        storage = FileStorage(tmp_path)
+        assert storage.rmdir("nonempty") is False
+        assert d.exists()
+
+    def test_rmdir_recursive(self, tmp_path):
+        d = tmp_path / "deep"
+        d.mkdir()
+        (d / "sub").mkdir()
+        (d / "sub" / "file.txt").write_text("x", encoding="utf-8")
+        storage = FileStorage(tmp_path)
+        assert storage.rmdir("deep", recursive=True) is True
+        assert not d.exists()
+
+    def test_rmdir_nonexistent(self, tmp_path):
+        storage = FileStorage(tmp_path)
+        assert storage.rmdir("ghost") is False
+
+
+# ---------------------------------------------------------------------------
+# list_dir
+# ---------------------------------------------------------------------------
+
+
+class TestFileStorageListDir:
+    """Tests for list_dir."""
+
+    def test_list_dir_with_files(self, tmp_path):
+        (tmp_path / "a.txt").write_text("a", encoding="utf-8")
+        (tmp_path / "b.txt").write_text("b", encoding="utf-8")
+        storage = FileStorage(tmp_path)
+        result = sorted(storage.list_dir("."))
+        assert "a.txt" in result
+        assert "b.txt" in result
+
+    def test_list_dir_with_subdirs(self, tmp_path):
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "file.txt").write_text("x", encoding="utf-8")
+        storage = FileStorage(tmp_path)
+        result = storage.list_dir(".")
+        assert "sub" in result
+        assert "file.txt" in result
+
+    def test_list_dir_nonexistent_returns_empty(self, tmp_path):
+        storage = FileStorage(tmp_path)
+        assert storage.list_dir("nope") == []
+
+    def test_list_dir_file_returns_empty(self, tmp_path):
+        """Listing a file (not a directory) returns empty list."""
+        (tmp_path / "f.txt").write_text("x", encoding="utf-8")
+        storage = FileStorage(tmp_path)
+        assert storage.list_dir("f.txt") == []
+
+
+# ---------------------------------------------------------------------------
+# glob
+# ---------------------------------------------------------------------------
+
+
+class TestFileStorageGlob:
+    """Tests for glob."""
+
+    def test_glob_txt_files(self, tmp_path):
+        (tmp_path / "a.txt").write_text("a", encoding="utf-8")
+        (tmp_path / "b.json").write_text("{}", encoding="utf-8")
+        storage = FileStorage(tmp_path)
+        result = list(storage.glob("*.txt"))
+        assert len(result) == 1
+        assert result[0].endswith("a.txt")
+
+    def test_glob_recursive(self, tmp_path):
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "root.py").write_text("", encoding="utf-8")
+        (tmp_path / "sub" / "deep.py").write_text("", encoding="utf-8")
+        storage = FileStorage(tmp_path)
+        result = sorted(storage.glob("**/*.py"))
+        assert len(result) == 2
+
+    def test_glob_no_matches(self, tmp_path):
+        (tmp_path / "file.txt").write_text("", encoding="utf-8")
+        storage = FileStorage(tmp_path)
+        result = list(storage.glob("*.json"))
+        assert result == []
+
+    def test_glob_nonexistent_dir(self, tmp_path):
+        storage = FileStorage(tmp_path)
+        result = list(storage.glob("*.txt", "nonexistent"))
+        assert result == []
+
+    def test_glob_with_subpath(self, tmp_path):
+        sub = tmp_path / "src"
+        sub.mkdir()
+        (sub / "main.py").write_text("", encoding="utf-8")
+        (sub / "util.py").write_text("", encoding="utf-8")
+        storage = FileStorage(tmp_path)
+        result = list(storage.glob("*.py", "src"))
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestFileStorageEdgeCases:
+    """Tests for edge cases."""
+
+    def test_string_path_accepted(self, tmp_path):
+        """FileStorage accepts str as root."""
+        storage = FileStorage(str(tmp_path))
+        assert storage.root == tmp_path.resolve()
+
+    def test_unicode_content(self, tmp_path):
+        storage = FileStorage(tmp_path)
+        storage.write("uni.txt", "Hello 世界 🌍")
+        assert storage.read("uni.txt") == "Hello 世界 🌍"
+
+    def test_empty_file(self, tmp_path):
+        storage = FileStorage(tmp_path)
+        storage.write("empty.txt", "")
+        assert storage.read("empty.txt") == ""
+        assert storage.exists("empty.txt") is True


### PR DESCRIPTION
## Summary

- Add Claude Code plugin marketplace support to `init-repo` and `upgrade-repo` (per-skill `plugin.json`, `marketplace.json`, `.listing.json`)
- Replace `auto-rebase.yml` with `skill-onboarding.md` agentic workflow so contributors only need to create `skill/<name>/SKILL.md` and open a PR — Copilot handles generating `version.txt`, `release-please-config.json`, and `.release-please-manifest.json` automatically
- Add 176 new tests for previously untested modules (ToolDetector, FileStorage, HttpRegistryClient, worktree CLI commands), bringing total from 647 to 829
- Fix cross-platform `FileStorage.delete()` bug (macOS `PermissionError` on directories)
- Fix `skill-onboarding.md` not being overwritten during upgrade (missing from critical infrastructure set)
- Fix unnecessary `issues:read` permission in skill-onboarding workflow by restricting GitHub toolsets to `[context, repos, pull_requests]`
- Refactor test infrastructure: extract `fake_home` fixture in `test_oauth.py`, replace `time.sleep` with deterministic time mocking, parametrize `TestFuzzyMatch`

## Changes by commit

| Commit | Type | Description |
|--------|------|-------------|
| `6a81dc2` | feat | Add `skills.json` regeneration to `upgrade-repo` |
| `60fdc5f` | feat | Add Claude Code plugin marketplace support |
| `de643d0` | fix | Regenerate per-skill `plugin.json` during `upgrade-repo` |
| `73ee5c0` | feat | Replace `auto-rebase.yml` with `skill-onboarding` agentic workflow |
| `b09ced5` | fix | Overwrite `skill-onboarding.md` on upgrade + remove obsolete `auto-rebase.yml` |
| `f314ff3` | test | Add 176 tests for untested modules + fix `FileStorage.delete()` cross-platform bug |
| `1f248ec` | fix | Restrict skill-onboarding toolsets to avoid unnecessary `issues:read` permission |

## Test results

829 passed, 0 failed (up from 647)

### New test coverage

| Module | Tests | Description |
|--------|-------|-------------|
| `ToolDetector` | 53 | Tool detection, path resolution, convenience functions |
| `FileStorage` | 42 | Read, write, delete, mkdir, rmdir, glob, edge cases |
| `HttpRegistryClient` | 64 | Auth, network ops, directory traversal security |
| Worktree CLI | 17 | All 5 commands (list, current, add, remove, prune) |